### PR TITLE
ci: validate native arm64 release runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           retention-days: 7
 
   arm64-runtime:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -63,15 +63,30 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - name: Test on native ARM64
+      - name: Install ARM64 emulator
         run: |
-          go test ./... -count=1
-          go test -race ./... -count=1
+          sudo apt-get update
+          sudo apt-get install --yes qemu-user-static
+      - name: Build ARM64 release binaries
+        env:
+          GOOS: linux
+          GOARCH: arm64
+          CGO_ENABLED: "0"
+        run: |
+          go build -trimpath -buildvcs=false -o /tmp/worldbisect-arm64 ./cmd/worldbisect
+          go build -trimpath -buildvcs=false -o /tmp/worldbisectd-arm64 ./cmd/worldbisectd
+      - name: Execute ARM64 binaries under emulation
+        run: |
+          qemu-aarch64-static /tmp/worldbisect-arm64 version
+          qemu-aarch64-static /tmp/worldbisectd-arm64 version
+      - name: Compile all packages for ARM64
+        run: |
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./...
       - name: End-to-end on native ARM64
         env:
           WORLDBISECT_E2E_RACE: "1"
         run: timeout --foreground 120s ./scripts/e2e.sh
-      - name: Package and execute ARM64 release binary
+      - name: Package and execute ARM64 release binary under emulation
         run: |
           make release
           tmp="$(mktemp -d)"
@@ -79,5 +94,5 @@ jobs:
           archive="dist/worldbisect_$(cat VERSION)_linux_arm64.tar.gz"
           tar -xzf "$archive" -C "$tmp"
           root="$tmp/worldbisect_$(cat VERSION)_linux_arm64"
-          "$root/bin/worldbisect" version
-          "$root/bin/worldbisectd" version
+          qemu-aarch64-static "$root/bin/worldbisect" version
+          qemu-aarch64-static "$root/bin/worldbisectd" version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,33 @@ jobs:
             coverage.out
           if-no-files-found: ignore
           retention-days: 7
+
+  arm64-runtime:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31d06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Test on native ARM64
+        run: |
+          go test ./... -count=1
+          go test -race ./... -count=1
+      - name: End-to-end on native ARM64
+        env:
+          WORLDBISECT_E2E_RACE: "1"
+        run: timeout --foreground 120s ./scripts/e2e.sh
+      - name: Package and execute ARM64 release binary
+        run: |
+          make release
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          archive="dist/worldbisect_$(cat VERSION)_linux_arm64.tar.gz"
+          tar -xzf "$archive" -C "$tmp"
+          root="$tmp/worldbisect_$(cat VERSION)_linux_arm64"
+          "$root/bin/worldbisect" version
+          "$root/bin/worldbisectd" version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
           cache: false
@@ -53,40 +53,25 @@ jobs:
           retention-days: 7
 
   arm64-runtime:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31d06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
           cache: false
-      - name: Install ARM64 emulator
+      - name: Test on native ARM64
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes qemu-user-static
-      - name: Build ARM64 release binaries
-        env:
-          GOOS: linux
-          GOARCH: arm64
-          CGO_ENABLED: "0"
-        run: |
-          go build -trimpath -buildvcs=false -o /tmp/worldbisect-arm64 ./cmd/worldbisect
-          go build -trimpath -buildvcs=false -o /tmp/worldbisectd-arm64 ./cmd/worldbisectd
-      - name: Execute ARM64 binaries under emulation
-        run: |
-          qemu-aarch64-static /tmp/worldbisect-arm64 version
-          qemu-aarch64-static /tmp/worldbisectd-arm64 version
-      - name: Compile all packages for ARM64
-        run: |
-          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./...
+          go test ./... -count=1
+          go test -race ./... -count=1
       - name: End-to-end on native ARM64
         env:
           WORLDBISECT_E2E_RACE: "1"
         run: timeout --foreground 120s ./scripts/e2e.sh
-      - name: Package and execute ARM64 release binary under emulation
+      - name: Package and execute ARM64 release binary
         run: |
           make release
           tmp="$(mktemp -d)"
@@ -94,5 +79,5 @@ jobs:
           archive="dist/worldbisect_$(cat VERSION)_linux_arm64.tar.gz"
           tar -xzf "$archive" -C "$tmp"
           root="$tmp/worldbisect_$(cat VERSION)_linux_arm64"
-          qemu-aarch64-static "$root/bin/worldbisect" version
-          qemu-aarch64-static "$root/bin/worldbisectd" version
+          "$root/bin/worldbisect" version
+          "$root/bin/worldbisectd" version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           retention-days: 7
 
   arm64-runtime:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,7 +64,8 @@ make coverage
 
 ## Architecture coverage
 
-The required GitHub Actions `arm64-runtime` job runs the test suite, race detector,
-E2E flow, and packaged ARM64 binaries on a native `ubuntu-22.04-arm` runner.
-Local Windows development still does not provide native ARM64 validation; the
-repository must not claim ARM64 validation when that CI job is not green.
+The required GitHub Actions `arm64-runtime` job cross-builds and executes the
+ARM64 binaries, tests, E2E flow, and packaged artifacts under QEMU emulation.
+This verifies ARM64 binary compatibility in CI, but is not a substitute for
+native ARM64 hardware validation. A release must not claim native hardware
+validation unless that hardware-specific check is separately green.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,6 +65,6 @@ make coverage
 ## Architecture coverage
 
 The required GitHub Actions `arm64-runtime` job runs the test suite, race detector,
-E2E flow, and packaged ARM64 binaries on a native `ubuntu-24.04-arm` runner.
+E2E flow, and packaged ARM64 binaries on a native `ubuntu-22.04-arm` runner.
 Local Windows development still does not provide native ARM64 validation; the
 repository must not claim ARM64 validation when that CI job is not green.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,4 +64,7 @@ make coverage
 
 ## Architecture coverage
 
-ARM64 packages are cross-compiled and checked as AArch64 ELF. Runtime validation on real ARM64 hardware is required before claiming native ARM64 execution has been tested for a release.
+The required GitHub Actions `arm64-runtime` job runs the test suite, race detector,
+E2E flow, and packaged ARM64 binaries on a native `ubuntu-24.04-arm` runner.
+Local Windows development still does not provide native ARM64 validation; the
+repository must not claim ARM64 validation when that CI job is not green.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,8 +64,7 @@ make coverage
 
 ## Architecture coverage
 
-The required GitHub Actions `arm64-runtime` job cross-builds and executes the
-ARM64 binaries, tests, E2E flow, and packaged artifacts under QEMU emulation.
-This verifies ARM64 binary compatibility in CI, but is not a substitute for
-native ARM64 hardware validation. A release must not claim native hardware
-validation unless that hardware-specific check is separately green.
+The required GitHub Actions `arm64-runtime` job runs the test suite, race detector,
+E2E flow, and packaged ARM64 binaries on a native `ubuntu-22.04-arm` runner.
+Local Windows development still does not provide native ARM64 validation; the
+repository must not claim ARM64 validation when that CI job is not green.


### PR DESCRIPTION
Adds a required native ARM64 CI job covering tests, race detection, E2E, packaging, and execution of the ARM64 release binaries. Updates testing documentation to match the verifiable gate.