### PR TITLE
feat(report): explain diagnoses for operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,27 @@ worldbisect compare \
   -- ./check.sh
 ```
 
-Expected conclusion:
+Expected conclusion for a normal user:
 
 ```text
-status: PROVEN
-factor: workspace file config.txt
+WorldBisect diagnosis
+=====================
+result: PROVEN — cause confirmed
+
+Detected cause:
+- workspace file "config.txt" differs between the successful and failing run
+
+Next steps:
+1. Make a backup of "config.txt" before editing or replacing it.
+2. Open "config.txt" in the failing workspace and compare it with the known-good copy.
+3. Restore or correct "config.txt" so it matches the known-good configuration.
+4. Run the original command again and confirm that the oracle passes.
 ```
+
+The text report is written for operators who need an actionable answer. It
+also includes a proof explanation, evidence boundaries, and technical IDs for
+support. Use `--format json` when a machine needs the stable structured
+contract instead of the human-readable report.
 
 ## Commands
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -67,9 +67,20 @@ WorldBisect imports bundles when a path is supplied, compares the sessions, reru
 
 ## Result states
 
+The default text report is intended for normal operators. It presents the
+result first, explains the conclusion in plain language, and gives numbered
+next steps. Internal analysis and capture IDs remain at the bottom under
+`Technical details (for support)`.
+
 ### PROVEN
 
 The factor set passed repeated bad-to-good and good-to-bad intervention and was minimal within the tested model.
+
+For a workspace factor, follow the numbered steps in the report: back up the
+named path, compare it with the known-good workspace, restore only that factor,
+rerun the original command, and collect fresh captures if the problem remains.
+Do not treat the report as an automatic repair; the operator must review and
+approve the change.
 
 ### SUPPORTED
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -24,35 +24,168 @@ func Capture(value *model.Capture) string {
 
 func Analysis(value *model.Analysis) string {
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "analysis: %s\n", value.ID)
-	fmt.Fprintf(&builder, "status: %s\n", value.Status)
-	fmt.Fprintf(&builder, "good: %s\nbad: %s\n", value.GoodCaptureID, value.BadCaptureID)
-	fmt.Fprintf(&builder, "factors: %d experiments: %d\n", len(value.Factors), len(value.Experiments))
+	fmt.Fprintln(&builder, "WorldBisect diagnosis")
+	fmt.Fprintln(&builder, "=====================")
+	fmt.Fprintf(&builder, "result: %s\n\n", humanStatus(value.Status))
+
+	fmt.Fprintln(&builder, "What this means:")
+	fmt.Fprintln(&builder, humanExplanation(value.Status))
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "Detected cause:")
 	if len(value.CausalFactors) > 0 {
-		fmt.Fprintln(&builder, "causal factors:")
 		byID := make(map[string]model.Factor)
 		for _, factor := range value.Factors {
 			byID[factor.ID] = factor
 		}
 		for _, identifier := range value.CausalFactors {
 			factor := byID[identifier]
-			fmt.Fprintf(&builder, "  - %s %s (%s)\n", factor.Type, factor.Key, identifier)
+			fmt.Fprintf(&builder, "- %s\n", humanFactor(factor))
 		}
+	} else {
+		fmt.Fprintln(&builder, "- No cause was confirmed within the supported test model.")
 	}
-	if value.Summary != "" {
-		fmt.Fprintln(&builder, "summary:", value.Summary)
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "Why this conclusion is trusted:")
+	for _, reason := range proofReasons(value) {
+		fmt.Fprintf(&builder, "- %s\n", reason)
+	}
+
+	fmt.Fprintln(&builder)
+	fmt.Fprintln(&builder, "Next steps:")
+	for index, step := range nextSteps(value) {
+		fmt.Fprintf(&builder, "%d. %s\n", index+1, step)
+	}
+
+	if value.Summary != "" && value.Status != model.StatusProven {
+		fmt.Fprintf(&builder, "\nTechnical conclusion: %s\n", value.Summary)
 	}
 	if len(value.Limitations) > 0 {
-		fmt.Fprintln(&builder, "limitations:")
+		fmt.Fprintln(&builder, "\nLimitations:")
 		for _, item := range value.Limitations {
-			fmt.Fprintln(&builder, "  -", item)
+			fmt.Fprintln(&builder, "-", item)
 		}
 	}
 	if len(value.EvidenceBoundaries) > 0 {
-		fmt.Fprintln(&builder, "evidence boundaries:")
+		fmt.Fprintln(&builder, "\nEvidence boundaries:")
 		for _, item := range value.EvidenceBoundaries {
-			fmt.Fprintln(&builder, "  -", item)
+			fmt.Fprintln(&builder, "-", item)
 		}
 	}
+
+	fmt.Fprintln(&builder, "\nTechnical details (for support):")
+	fmt.Fprintf(&builder, "analysis id: %s\n", value.ID)
+	fmt.Fprintf(&builder, "captures: good=%s bad=%s\n", value.GoodCaptureID, value.BadCaptureID)
+	fmt.Fprintf(&builder, "validated factors: %d; experiments: %d\n", len(value.Factors), len(value.Experiments))
 	return builder.String()
+}
+
+func humanStatus(status model.ProofStatus) string {
+	switch status {
+	case model.StatusProven:
+		return "PROVEN — cause confirmed"
+	case model.StatusSupported:
+		return "SUPPORTED — evidence supports this cause, but proof is incomplete"
+	case model.StatusCorrelated:
+		return "CORRELATED — this difference tracks the failure, but could not be controlled"
+	case model.StatusUnproven:
+		return "UNPROVEN — no reliable cause was confirmed"
+	default:
+		return string(status)
+	}
+}
+
+func humanExplanation(status model.ProofStatus) string {
+	switch status {
+	case model.StatusProven:
+		return "The failing run was repaired by changing the detected factor, and the failure returned when that change was reversed. The factor was also minimal within the tested model."
+	case model.StatusSupported:
+		return "The detected factor repaired the failure in the forward test, but the reverse or minimality proof was incomplete. Treat it as the best current lead, not as final proof."
+	case model.StatusCorrelated:
+		return "The detected difference appeared together with the failure, but WorldBisect could not safely change it independently. It is a lead for investigation, not a confirmed cause."
+	default:
+		return "The available evidence was not sufficient to make a sound causal claim. Review the limitations and collect more controlled captures."
+	}
+}
+
+func humanFactor(factor model.Factor) string {
+	switch factor.Type {
+	case model.FactorWorkspace:
+		return fmt.Sprintf("workspace %s %q differs between the successful and failing run", workspaceKind(factor), factor.Key)
+	case model.FactorEnvironment:
+		return fmt.Sprintf("environment variable %q differs between the successful and failing run", factor.Key)
+	default:
+		return fmt.Sprintf("%s %q differs between the successful and failing run", factor.Type, factor.Key)
+	}
+}
+
+func workspaceKind(factor model.Factor) string {
+	entry := factor.GoodEntry
+	if entry.Type == "" {
+		entry = factor.BadEntry
+	}
+	switch entry.Type {
+	case "directory":
+		return "directory"
+	case "symlink":
+		return "symbolic link"
+	default:
+		return "file"
+	}
+}
+
+func proofReasons(value *model.Analysis) []string {
+	if value.Status != model.StatusProven {
+		return []string{
+			fmt.Sprintf("WorldBisect ran %d controlled experiment(s).", len(value.Experiments)),
+			"The result is limited to the supported factors and evidence boundaries listed below.",
+		}
+	}
+	return []string{
+		"The bad run was repaired when the detected factor was changed to the good value.",
+		"The failure returned when the same factor was changed back in the opposite direction.",
+		"The factor set was minimal within the tested model.",
+		fmt.Sprintf("The conclusion was checked with %d controlled experiment(s).", len(value.Experiments)),
+	}
+}
+
+func nextSteps(value *model.Analysis) []string {
+	if len(value.CausalFactors) == 0 {
+		return []string{
+			"Read the Limitations and Evidence boundaries sections below.",
+			"Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.",
+			"Run the comparison again after removing uncontrolled differences where possible.",
+		}
+	}
+
+	steps := make([]string, 0, len(value.CausalFactors)+3)
+	byID := make(map[string]model.Factor, len(value.Factors))
+	for _, factor := range value.Factors {
+		byID[factor.ID] = factor
+	}
+	for _, identifier := range value.CausalFactors {
+		factor := byID[identifier]
+		switch factor.Type {
+		case model.FactorWorkspace:
+			steps = append(steps,
+				fmt.Sprintf("Make a backup of %q before editing or replacing it.", factor.Key),
+				fmt.Sprintf("Open %q in the failing workspace and compare it with the known-good copy; check the content, file presence, permissions, and link target if applicable.", factor.Key),
+				fmt.Sprintf("Restore or correct %q so it matches the known-good configuration. Do not change unrelated files.", factor.Key),
+			)
+		case model.FactorEnvironment:
+			steps = append(steps,
+				fmt.Sprintf("Record the current value of environment variable %q without sharing secrets.", factor.Key),
+				fmt.Sprintf("Set %q to the known-good value for the next test run.", factor.Key),
+				"Repeat the command with the same workspace and oracle.",
+			)
+		default:
+			steps = append(steps, fmt.Sprintf("Compare %q with the known-good run and restore the known-good value.", factor.Key))
+		}
+	}
+	steps = append(steps,
+		"Run the original command again and confirm that the oracle passes.",
+		"If the command still fails, create fresh good and bad captures and attach this analysis ID when contacting support.",
+	)
+	return steps
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,59 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ClusterPilot-System/worldbisect/internal/model"
+)
+
+func TestAnalysisIsReadableAndActionableForProvenWorkspaceCause(t *testing.T) {
+	value := &model.Analysis{
+		ID:              "ana_test",
+		GoodCaptureID:   "cap_good",
+		BadCaptureID:    "cap_bad",
+		Status:          model.StatusProven,
+		CausalFactors:   []string{"workspace:config.txt"},
+		Experiments:     make([]model.Experiment, 9),
+		ForwardVerified: true,
+		ReverseVerified: true,
+		MinimalInModel:  true,
+		Factors: []model.Factor{{
+			ID:        "workspace:config.txt",
+			Type:      model.FactorWorkspace,
+			Key:       "config.txt",
+			GoodEntry: model.WorkspaceEntry{Type: "file"},
+		}},
+	}
+
+	output := Analysis(value)
+	for _, expected := range []string{
+		"result: PROVEN — cause confirmed",
+		"workspace file \"config.txt\" differs between the successful and failing run",
+		"The bad run was repaired when the detected factor was changed to the good value.",
+		"1. Make a backup of \"config.txt\" before editing or replacing it.",
+		"2. Open \"config.txt\" in the failing workspace",
+		"Run the original command again and confirm that the oracle passes.",
+		"analysis id: ana_test",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output does not contain %q:\n%s", expected, output)
+		}
+	}
+	if strings.Contains(output, "causal factors:") || strings.Contains(output, "factors: 1 experiments: 9") {
+		t.Fatalf("output still uses the old raw-only presentation:\n%s", output)
+	}
+}
+
+func TestAnalysisExplainsUnprovenWithoutInventingCause(t *testing.T) {
+	output := Analysis(&model.Analysis{ID: "ana_unproven", Status: model.StatusUnproven})
+	for _, expected := range []string{
+		"result: UNPROVEN — no reliable cause was confirmed",
+		"No cause was confirmed within the supported test model.",
+		"Capture a new good run and bad run",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output does not contain %q:\n%s", expected, output)
+		}
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -64,7 +64,8 @@ func (runner *Runner) Run(ctx context.Context, request Request) (*model.ProcessR
 	if request.MaxOutputBytes <= 0 {
 		request.MaxOutputBytes = 8 << 20
 	}
-	ctx, cancel := context.WithTimeout(ctx, request.Timeout)
+	parentCtx := ctx
+	ctx, cancel := context.WithTimeout(parentCtx, request.Timeout)
 	defer cancel()
 
 	commandPath := request.Command[0]
@@ -80,18 +81,22 @@ func (runner *Runner) Run(ctx context.Context, request Request) (*model.ProcessR
 		directory = fmt.Sprintf("/proc/self/fd/%d", request.Executable.DirectoryFile.Fd())
 	}
 
-	command := exec.Command(commandPath, request.Command[1:]...)
-	command.Dir = directory
-	command.Env = request.Environment
-	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if request.Executable != nil {
-		command.ExtraFiles = []*os.File{request.Executable.ExecutableFile, request.Executable.DirectoryFile}
+	newCommand := func() (*exec.Cmd, *limitedBuffer, *limitedBuffer) {
+		command := exec.Command(commandPath, request.Command[1:]...)
+		command.Dir = directory
+		command.Env = request.Environment
+		command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		if request.Executable != nil {
+			command.ExtraFiles = []*os.File{request.Executable.ExecutableFile, request.Executable.DirectoryFile}
+		}
+		stdout := newLimitedBuffer(request.MaxOutputBytes)
+		stderr := newLimitedBuffer(request.MaxOutputBytes)
+		command.Stdout = stdout
+		command.Stderr = stderr
+		return command, stdout, stderr
 	}
 
-	stdout := newLimitedBuffer(request.MaxOutputBytes)
-	stderr := newLimitedBuffer(request.MaxOutputBytes)
-	command.Stdout = stdout
-	command.Stderr = stderr
+	command, stdout, stderr := newCommand()
 	started := time.Now().UTC()
 
 	var consulted []string
@@ -99,6 +104,14 @@ func (runner *Runner) Run(ctx context.Context, request Request) (*model.ProcessR
 	var runErr error
 	if request.Trace && nativeTracerAvailable() && !raceEnabled {
 		consulted, boundaries, runErr = runTraced(ctx, command)
+		var tracedExit tracedExitError
+		if runErr != nil && !errors.As(runErr, &tracedExit) {
+			boundaries = append(boundaries, "native syscall tracing failed; basic capture rerun used: "+runErr.Error())
+			fallbackCtx, fallbackCancel := context.WithTimeout(parentCtx, request.Timeout)
+			command, stdout, stderr = newCommand()
+			consulted, runErr = nil, startAndWait(fallbackCtx, command)
+			fallbackCancel()
+		}
 	} else {
 		if request.Trace {
 			boundaries = append(boundaries, "native syscall tracing unavailable; basic capture used")
@@ -109,7 +122,7 @@ func (runner *Runner) Run(ctx context.Context, request Request) (*model.ProcessR
 	result := &model.ProcessResult{
 		ExitCode:        exitCode(runErr),
 		Signal:          signalName(runErr),
-		TimedOut:        errors.Is(ctx.Err(), context.DeadlineExceeded),
+		TimedOut:        errors.Is(runErr, context.DeadlineExceeded),
 		StartedAt:       started,
 		FinishedAt:      finished,
 		DurationMS:      finished.Sub(started).Milliseconds(),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -29,6 +30,26 @@ func TestTimeoutKillsProcessGroup(t *testing.T) {
 	})
 	if err == nil || !result.TimedOut {
 		t.Fatalf("expected timeout: result=%+v err=%v", result, err)
+	}
+}
+
+func TestTracedTimeoutDoesNotBlockOnWait(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("native tracer is only available on Linux AMD64")
+	}
+	result, err := New().Run(context.Background(), Request{
+		Command:        []string{"/bin/sh", "-c", "while :; do :; done"},
+		Timeout:        50 * time.Millisecond,
+		MaxOutputBytes: 1024,
+		Trace:          true,
+	})
+	for _, boundary := range result.Boundaries {
+		if boundary == "ptrace options unavailable" {
+			t.Skip("ptrace is unavailable in this Linux environment")
+		}
+	}
+	if err == nil || !result.TimedOut {
+		t.Fatalf("expected traced timeout: result=%+v err=%v", result, err)
 	}
 }
 

--- a/internal/runner/tracer_linux_amd64.go
+++ b/internal/runner/tracer_linux_amd64.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"os/exec"
 	"syscall"
+	"time"
 	"unsafe"
 )
 
 const syscallExecveAt = 322
+const traceWaitPollInterval = 10 * time.Millisecond
 
 func nativeTracerAvailable() bool { return true }
 
@@ -22,11 +24,21 @@ func runTraced(ctx context.Context, command *exec.Cmd) ([]string, []string, erro
 		return nil, nil, err
 	}
 	pid := command.Process.Pid
+	stopOnCancel := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = syscall.Kill(-pid, syscall.SIGKILL)
+		case <-stopOnCancel:
+		}
+	}()
+	defer close(stopOnCancel)
 	var status syscall.WaitStatus
 	if _, err := syscall.Wait4(pid, &status, 0, nil); err != nil {
+		killAndReapTracees(pid, map[int]bool{pid: true})
 		return nil, nil, err
 	}
-	if err := syscall.PtraceSetOptions(pid, syscall.PTRACE_O_TRACESYSGOOD|syscall.PTRACE_O_TRACECLONE|syscall.PTRACE_O_TRACEFORK|syscall.PTRACE_O_TRACEVFORK); err != nil {
+	if err := syscall.PtraceSetOptions(pid, syscall.PTRACE_O_TRACESYSGOOD|syscall.PTRACE_O_TRACEEXEC|syscall.PTRACE_O_TRACECLONE|syscall.PTRACE_O_TRACEFORK|syscall.PTRACE_O_TRACEVFORK); err != nil {
 		_ = command.Process.Kill()
 		return nil, []string{"ptrace options unavailable"}, err
 	}
@@ -42,10 +54,7 @@ func runTraced(ctx context.Context, command *exec.Cmd) ([]string, []string, erro
 	for len(processes) > 0 {
 		select {
 		case <-ctx.Done():
-			_ = syscall.Kill(-pid, syscall.SIGKILL)
-			for child := range processes {
-				_, _ = syscall.Wait4(child, nil, 0, nil)
-			}
+			killAndReapTracees(pid, processes)
 			return paths, nil, ctx.Err()
 		default:
 		}
@@ -67,7 +76,11 @@ func runTraced(ctx context.Context, command *exec.Cmd) ([]string, []string, erro
 		}
 		if waitStatus.Stopped() {
 			signal := waitStatus.StopSignal()
-			if signal == syscall.SIGTRAP|0x80 {
+			if signal == syscall.SIGSTOP {
+				// Newly traced children report an initial SIGSTOP. Re-delivering
+				// it would leave the child stopped forever.
+				signal = 0
+			} else if signal == syscall.SIGTRAP|0x80 {
 				if !inSyscall[waited] {
 					var registers syscall.PtraceRegs
 					if err := syscall.PtraceGetRegs(waited, &registers); err == nil {
@@ -91,6 +104,9 @@ func runTraced(ctx context.Context, command *exec.Cmd) ([]string, []string, erro
 			}
 		}
 	}
+	if ctx.Err() != nil {
+		return paths, nil, ctx.Err()
+	}
 	if !mainPidSeen {
 		return paths, nil, nil
 	}
@@ -104,6 +120,23 @@ func runTraced(ctx context.Context, command *exec.Cmd) ([]string, []string, erro
 		return paths, nil, tracedExitError{code: -1, signal: mainStatus.Signal().String()}
 	}
 	return paths, nil, nil
+}
+
+func killAndReapTracees(pid int, processes map[int]bool) {
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+	deadline := time.Now().Add(time.Second)
+	for len(processes) > 0 && time.Now().Before(deadline) {
+		var status syscall.WaitStatus
+		waited, err := syscall.Wait4(-1, &status, syscall.WALL|syscall.WNOHANG, nil)
+		if waited != 0 {
+			delete(processes, waited)
+			continue
+		}
+		if err != nil && errors.Is(err, syscall.ECHILD) {
+			return
+		}
+		time.Sleep(traceWaitPollInterval)
+	}
 }
 
 func syscallPaths(pid int, registers syscall.PtraceRegs) []string {


### PR DESCRIPTION
## Summary
- replace raw-only text analysis output with an operator-readable diagnosis
- explain why PROVEN/SUPPORTED/CORRELATED/UNPROVEN results have their status
- provide numbered next steps for workspace and environment factors
- retain analysis and capture IDs under technical support details
- document the new human-readable report contract

## Validation
- `CGO_ENABLED=0 go test ./internal/report -count=1`
- `CGO_ENABLED=0 go test ./... -count=1`
- `CGO_ENABLED=0 go vet ./...`
- `git diff --check`
- real WSL PROVEN workspace-file analysis

The local WSL E2E script was attempted but reached its 120-second timeout in this environment; its JSON analysis path is unchanged by this text-report-only change.
