### PR TITLE
feat(report): add stable Markdown and JSON report formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,25 +99,35 @@ worldbisect compare \
 
 Expected conclusion for a normal user:
 
-```text
-WorldBisect diagnosis
-=====================
-result: PROVEN — cause confirmed
+```markdown
+# WorldBisect diagnosis
 
-Detected cause:
-- workspace file "config.txt" differs between the successful and failing run
+**Status:** `PROVEN`
 
-Next steps:
+The failing run was repaired by changing the detected factor, and the failure returned when that change was reversed. The factor was also minimal within the tested model.
+
+## Confirmed or suspected cause
+
+- `workspace:config.txt` — workspace file "config.txt" differs between the successful and failing run
+
+## Next steps
+
 1. Make a backup of "config.txt" before editing or replacing it.
-2. Open "config.txt" in the failing workspace and compare it with the known-good copy.
-3. Restore or correct "config.txt" so it matches the known-good configuration.
+2. Open "config.txt" in the failing workspace and compare it with the known-good copy; check the content, file presence, permissions, and link target if applicable.
+3. Restore or correct "config.txt" so it matches the known-good configuration. Do not change unrelated files.
 4. Run the original command again and confirm that the oracle passes.
+5. If the command still fails, create fresh good and bad captures and attach this analysis ID when contacting support.
 ```
 
 The text report is written for operators who need an actionable answer. It
 also includes a proof explanation, evidence boundaries, and technical IDs for
 support. Use `--format json` when a machine needs the stable structured
 contract instead of the human-readable report.
+
+The JSON output is the versioned `worldbisect.analysis-report.v1` contract.
+Markdown output is also stable and can be pasted into GitHub pull requests or
+support tickets. Both formats are derived from the same report model and omit
+captured command output and factor values.
 
 ## Commands
 

--- a/cmd/worldbisect/main.go
+++ b/cmd/worldbisect/main.go
@@ -241,10 +241,7 @@ func runCompare(args []string, stdout io.Writer) error {
 		}
 	}
 	if analysis != nil {
-		if *format == "json" {
-			return writeJSON(stdout, analysis)
-		}
-		fmt.Fprint(stdout, report.Analysis(analysis))
+		return writeAnalysis(stdout, analysis, *format)
 	}
 	return err
 }
@@ -275,11 +272,24 @@ func runExplain(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if *format == "json" {
-		return writeJSON(stdout, analysis)
+	return writeAnalysis(stdout, analysis, *format)
+}
+
+func writeAnalysis(stdout io.Writer, analysis *model.Analysis, format string) error {
+	switch format {
+	case "text", "markdown":
+		_, err := fmt.Fprint(stdout, report.Markdown(analysis))
+		return err
+	case "json":
+		encoded, err := report.JSON(analysis)
+		if err != nil {
+			return err
+		}
+		_, err = stdout.Write(encoded)
+		return err
+	default:
+		return fmt.Errorf("unsupported analysis format %q (use text, markdown, or json)", format)
 	}
-	fmt.Fprint(stdout, report.Analysis(analysis))
-	return nil
 }
 
 func runExport(args []string, stdout io.Writer) error {

--- a/docs/man/worldbisect.1
+++ b/docs/man/worldbisect.1
@@ -31,6 +31,10 @@ Compare good and bad captures and run causal experiments.
 .TP
 .B explain
 Render a stored analysis.
+.PP
+Analysis reports default to stable Markdown. Use B--format markdownR for
+explicit Markdown output or B--format jsonR for the versioned
+Bworldbisect.analysis-report.v1R automation contract.
 .TP
 .B export
 Create a deterministic portable capture bundle.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -100,7 +100,14 @@ No sound causal claim can be made. Read the limitations and experiment diagnosti
 worldbisect explain --store /tmp/wb-store <analysis-id>
 ```
 
-Use `--format json` for automation.
+The default output is stable Markdown and can be pasted directly into a GitHub
+pull request or support ticket. Use `--format markdown` explicitly when a
+script needs to document the chosen presentation. Use `--format json` for the
+versioned `worldbisect.analysis-report.v1` automation contract. Its top-level
+fields are `schema_version`, `status`, `proof`, `cause`, `boundaries`,
+`limitations`, `next_steps`, and `evidence`. The report deliberately omits
+captured command output and factor values; use a reviewed diagnostic bundle for
+that sensitive evidence.
 
 ## Export and import
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,11 +1,152 @@
 package report
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ClusterPilot-System/worldbisect/internal/model"
 )
+
+const AnalysisReportSchemaVersion = 1
+
+// AnalysisReport is the stable, secret-safe public representation of an analysis.
+// Keep this separate from model.Analysis so persisted internals can evolve without
+// changing the automation and support contract emitted by the CLI.
+type AnalysisReport struct {
+	SchemaVersion int            `json:"schema_version"`
+	Format        string         `json:"format"`
+	AnalysisID    string         `json:"analysis_id"`
+	Status        string         `json:"status"`
+	Explanation   string         `json:"explanation"`
+	Proof         ReportProof    `json:"proof"`
+	Cause         []ReportFactor `json:"cause"`
+	Boundaries    []string       `json:"boundaries"`
+	Limitations   []string       `json:"limitations"`
+	NextSteps     []string       `json:"next_steps"`
+	Evidence      ReportEvidence `json:"evidence"`
+	Summary       string         `json:"summary,omitempty"`
+}
+
+type ReportProof struct {
+	ForwardVerified bool `json:"forward_verified"`
+	ReverseVerified bool `json:"reverse_verified"`
+	MinimalInModel  bool `json:"minimal_in_model"`
+}
+
+type ReportFactor struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Key         string `json:"key"`
+	Description string `json:"description"`
+}
+
+type ReportEvidence struct {
+	GoodCaptureID   string `json:"good_capture_id"`
+	BadCaptureID    string `json:"bad_capture_id"`
+	FactorCount     int    `json:"factor_count"`
+	ExperimentCount int    `json:"experiment_count"`
+}
+
+// Build derives every supported output format from one deterministic report value.
+func Build(value *model.Analysis) AnalysisReport {
+	byID := make(map[string]model.Factor, len(value.Factors))
+	for _, factor := range value.Factors {
+		byID[factor.ID] = factor
+	}
+
+	identifiers := append([]string(nil), value.CausalFactors...)
+	sort.Strings(identifiers)
+	cause := make([]ReportFactor, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		factor, found := byID[identifier]
+		if !found {
+			cause = append(cause, ReportFactor{ID: identifier, Description: "factor metadata was not available in this analysis"})
+			continue
+		}
+		cause = append(cause, ReportFactor{
+			ID: identifier, Type: string(factor.Type), Key: factor.Key,
+			Description: humanFactor(factor),
+		})
+	}
+
+	boundaries := append(make([]string, 0, len(value.EvidenceBoundaries)), value.EvidenceBoundaries...)
+	limitations := append(make([]string, 0, len(value.Limitations)), value.Limitations...)
+	sort.Strings(boundaries)
+	sort.Strings(limitations)
+	return AnalysisReport{
+		SchemaVersion: AnalysisReportSchemaVersion,
+		Format:        "worldbisect.analysis-report.v1",
+		AnalysisID:    value.ID,
+		Status:        string(value.Status),
+		Explanation:   humanExplanation(value.Status),
+		Proof: ReportProof{
+			ForwardVerified: value.ForwardVerified,
+			ReverseVerified: value.ReverseVerified,
+			MinimalInModel:  value.MinimalInModel,
+		},
+		Cause:       cause,
+		Boundaries:  boundaries,
+		Limitations: limitations,
+		NextSteps:   nextSteps(value),
+		Evidence: ReportEvidence{
+			GoodCaptureID:   value.GoodCaptureID,
+			BadCaptureID:    value.BadCaptureID,
+			FactorCount:     len(value.Factors),
+			ExperimentCount: len(value.Experiments),
+		},
+		Summary: value.Summary,
+	}
+}
+
+// JSON returns the versioned machine-readable report contract.
+func JSON(value *model.Analysis) ([]byte, error) {
+	encoded, err := json.MarshalIndent(Build(value), "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+// Markdown returns a stable report suitable for GitHub comments and support tickets.
+func Markdown(value *model.Analysis) string {
+	report := Build(value)
+	var builder strings.Builder
+	fmt.Fprintln(&builder, "# WorldBisect diagnosis")
+	fmt.Fprintf(&builder, "\n**Status:** `%s`\n\n%s\n", report.Status, report.Explanation)
+	fmt.Fprintln(&builder, "## Proof")
+	fmt.Fprintf(&builder, "\n- Forward intervention verified: `%t`\n- Reverse intervention verified: `%t`\n- Minimal within tested model: `%t`\n", report.Proof.ForwardVerified, report.Proof.ReverseVerified, report.Proof.MinimalInModel)
+	fmt.Fprintln(&builder, "\n## Confirmed or suspected cause")
+	if len(report.Cause) == 0 {
+		fmt.Fprintln(&builder, "\nNo cause was confirmed within the supported test model.")
+	} else {
+		for _, factor := range report.Cause {
+			fmt.Fprintf(&builder, "\n- `%s` — %s", factor.ID, factor.Description)
+		}
+		fmt.Fprintln(&builder)
+	}
+	fmt.Fprintln(&builder, "\n## Next steps")
+	for index, step := range report.NextSteps {
+		fmt.Fprintf(&builder, "%d. %s\n", index+1, step)
+	}
+	if len(report.Boundaries) > 0 {
+		fmt.Fprintln(&builder, "\n## Evidence boundaries")
+		for _, boundary := range report.Boundaries {
+			fmt.Fprintf(&builder, "\n- %s", boundary)
+		}
+		fmt.Fprintln(&builder)
+	}
+	if len(report.Limitations) > 0 {
+		fmt.Fprintln(&builder, "\n## Limitations")
+		for _, limitation := range report.Limitations {
+			fmt.Fprintf(&builder, "\n- %s", limitation)
+		}
+		fmt.Fprintln(&builder)
+	}
+	fmt.Fprintf(&builder, "\n<sub>Analysis `%s`; experiments: %d; factors: %d.</sub>\n", report.AnalysisID, report.Evidence.ExperimentCount, report.Evidence.FactorCount)
+	return builder.String()
+}
 
 func Capture(value *model.Capture) string {
 	var builder strings.Builder
@@ -23,77 +164,7 @@ func Capture(value *model.Capture) string {
 }
 
 func Analysis(value *model.Analysis) string {
-	var builder strings.Builder
-	fmt.Fprintln(&builder, "WorldBisect diagnosis")
-	fmt.Fprintln(&builder, "=====================")
-	fmt.Fprintf(&builder, "result: %s\n\n", humanStatus(value.Status))
-
-	fmt.Fprintln(&builder, "What this means:")
-	fmt.Fprintln(&builder, humanExplanation(value.Status))
-	fmt.Fprintln(&builder)
-
-	fmt.Fprintln(&builder, "Detected cause:")
-	if len(value.CausalFactors) > 0 {
-		byID := make(map[string]model.Factor)
-		for _, factor := range value.Factors {
-			byID[factor.ID] = factor
-		}
-		for _, identifier := range value.CausalFactors {
-			factor := byID[identifier]
-			fmt.Fprintf(&builder, "- %s\n", humanFactor(factor))
-		}
-	} else {
-		fmt.Fprintln(&builder, "- No cause was confirmed within the supported test model.")
-	}
-	fmt.Fprintln(&builder)
-
-	fmt.Fprintln(&builder, "Why this conclusion is trusted:")
-	for _, reason := range proofReasons(value) {
-		fmt.Fprintf(&builder, "- %s\n", reason)
-	}
-
-	fmt.Fprintln(&builder)
-	fmt.Fprintln(&builder, "Next steps:")
-	for index, step := range nextSteps(value) {
-		fmt.Fprintf(&builder, "%d. %s\n", index+1, step)
-	}
-
-	if value.Summary != "" && value.Status != model.StatusProven {
-		fmt.Fprintf(&builder, "\nTechnical conclusion: %s\n", value.Summary)
-	}
-	if len(value.Limitations) > 0 {
-		fmt.Fprintln(&builder, "\nLimitations:")
-		for _, item := range value.Limitations {
-			fmt.Fprintln(&builder, "-", item)
-		}
-	}
-	if len(value.EvidenceBoundaries) > 0 {
-		fmt.Fprintln(&builder, "\nEvidence boundaries:")
-		for _, item := range value.EvidenceBoundaries {
-			fmt.Fprintln(&builder, "-", item)
-		}
-	}
-
-	fmt.Fprintln(&builder, "\nTechnical details (for support):")
-	fmt.Fprintf(&builder, "analysis id: %s\n", value.ID)
-	fmt.Fprintf(&builder, "captures: good=%s bad=%s\n", value.GoodCaptureID, value.BadCaptureID)
-	fmt.Fprintf(&builder, "validated factors: %d; experiments: %d\n", len(value.Factors), len(value.Experiments))
-	return builder.String()
-}
-
-func humanStatus(status model.ProofStatus) string {
-	switch status {
-	case model.StatusProven:
-		return "PROVEN — cause confirmed"
-	case model.StatusSupported:
-		return "SUPPORTED — evidence supports this cause, but proof is incomplete"
-	case model.StatusCorrelated:
-		return "CORRELATED — this difference tracks the failure, but could not be controlled"
-	case model.StatusUnproven:
-		return "UNPROVEN — no reliable cause was confirmed"
-	default:
-		return string(status)
-	}
+	return Markdown(value)
 }
 
 func humanExplanation(status model.ProofStatus) string {
@@ -132,21 +203,6 @@ func workspaceKind(factor model.Factor) string {
 		return "symbolic link"
 	default:
 		return "file"
-	}
-}
-
-func proofReasons(value *model.Analysis) []string {
-	if value.Status != model.StatusProven {
-		return []string{
-			fmt.Sprintf("WorldBisect ran %d controlled experiment(s).", len(value.Experiments)),
-			"The result is limited to the supported factors and evidence boundaries listed below.",
-		}
-	}
-	return []string{
-		"The bad run was repaired when the detected factor was changed to the good value.",
-		"The failure returned when the same factor was changed back in the opposite direction.",
-		"The factor set was minimal within the tested model.",
-		fmt.Sprintf("The conclusion was checked with %d controlled experiment(s).", len(value.Experiments)),
 	}
 }
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,59 +1,107 @@
 package report
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ClusterPilot-System/worldbisect/internal/model"
 )
 
-func TestAnalysisIsReadableAndActionableForProvenWorkspaceCause(t *testing.T) {
-	value := &model.Analysis{
-		ID:              "ana_test",
-		GoodCaptureID:   "cap_good",
-		BadCaptureID:    "cap_bad",
-		Status:          model.StatusProven,
-		CausalFactors:   []string{"workspace:config.txt"},
-		Experiments:     make([]model.Experiment, 9),
-		ForwardVerified: true,
-		ReverseVerified: true,
-		MinimalInModel:  true,
-		Factors: []model.Factor{{
-			ID:        "workspace:config.txt",
-			Type:      model.FactorWorkspace,
-			Key:       "config.txt",
-			GoodEntry: model.WorkspaceEntry{Type: "file"},
-		}},
-	}
-
-	output := Analysis(value)
-	for _, expected := range []string{
-		"result: PROVEN — cause confirmed",
-		"workspace file \"config.txt\" differs between the successful and failing run",
-		"The bad run was repaired when the detected factor was changed to the good value.",
-		"1. Make a backup of \"config.txt\" before editing or replacing it.",
-		"2. Open \"config.txt\" in the failing workspace",
-		"Run the original command again and confirm that the oracle passes.",
-		"analysis id: ana_test",
-	} {
-		if !strings.Contains(output, expected) {
-			t.Fatalf("output does not contain %q:\n%s", expected, output)
-		}
-	}
-	if strings.Contains(output, "causal factors:") || strings.Contains(output, "factors: 1 experiments: 9") {
-		t.Fatalf("output still uses the old raw-only presentation:\n%s", output)
+func provenAnalysis() *model.Analysis {
+	return &model.Analysis{
+		ID: "ana_test", GoodCaptureID: "cap_good", BadCaptureID: "cap_bad",
+		Status: model.StatusProven, ForwardVerified: true, ReverseVerified: true, MinimalInModel: true,
+		CausalFactors: []string{"workspace:config.txt"}, Experiments: make([]model.Experiment, 9),
+		Factors:            []model.Factor{{ID: "workspace:config.txt", Type: model.FactorWorkspace, Key: "config.txt", GoodEntry: model.WorkspaceEntry{Type: "file"}}},
+		EvidenceBoundaries: []string{"host scheduling was not controlled"},
+		Limitations:        []string{"proof applies only to the supported intervention model"},
 	}
 }
 
-func TestAnalysisExplainsUnprovenWithoutInventingCause(t *testing.T) {
-	output := Analysis(&model.Analysis{ID: "ana_unproven", Status: model.StatusUnproven})
+func TestAnalysisReportJSONHasStableContract(t *testing.T) {
+	encoded, err := JSON(provenAnalysis())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(encoded, &value); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"schema_version", "format", "analysis_id", "status", "explanation", "proof", "cause", "boundaries", "limitations", "next_steps", "evidence"} {
+		if _, ok := value[field]; !ok {
+			t.Fatalf("stable report field %q missing from %s", field, encoded)
+		}
+	}
+	if value["schema_version"] != float64(1) || value["format"] != "worldbisect.analysis-report.v1" || value["status"] != "PROVEN" {
+		t.Fatalf("unexpected report identity: %s", encoded)
+	}
+	if strings.Contains(string(encoded), "good_value") || strings.Contains(string(encoded), "bad_value") {
+		t.Fatalf("report exposed internal factor values: %s", encoded)
+	}
+}
+
+func TestAnalysisReportMarkdownIsGitHubReady(t *testing.T) {
+	output := Markdown(provenAnalysis())
 	for _, expected := range []string{
-		"result: UNPROVEN — no reliable cause was confirmed",
-		"No cause was confirmed within the supported test model.",
-		"Capture a new good run and bad run",
+		"# WorldBisect diagnosis", "**Status:** `PROVEN`", "## Proof",
+		"## Confirmed or suspected cause", "workspace file \"config.txt\"",
+		"## Next steps", "## Evidence boundaries", "Analysis `ana_test`",
 	} {
 		if !strings.Contains(output, expected) {
-			t.Fatalf("output does not contain %q:\n%s", expected, output)
+			t.Fatalf("markdown does not contain %q:\n%s", expected, output)
 		}
+	}
+}
+
+func TestMarkdownStatusSnapshots(t *testing.T) {
+	for _, status := range []model.ProofStatus{model.StatusProven, model.StatusSupported, model.StatusCorrelated, model.StatusUnproven} {
+		t.Run(string(status), func(t *testing.T) {
+			value := &model.Analysis{ID: "ana_" + strings.ToLower(string(status)), Status: status}
+			path := filepath.Join("testdata", "status_"+strings.ToLower(string(status))+".md")
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := Markdown(value); string(want) != got {
+				t.Fatalf("markdown snapshot changed for %s:\n%s", status, got)
+			}
+		})
+	}
+}
+
+func TestEveryStatusHasUnambiguousContractAndMarkdown(t *testing.T) {
+	statuses := []model.ProofStatus{model.StatusProven, model.StatusSupported, model.StatusCorrelated, model.StatusUnproven}
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			value := &model.Analysis{ID: "ana_" + strings.ToLower(string(status)), Status: status}
+			report := Build(value)
+			if report.Status != string(status) || report.Explanation == "" {
+				t.Fatalf("status is not explicit: %#v", report)
+			}
+			if !strings.Contains(Markdown(value), "**Status:** `"+string(status)+"`") {
+				t.Fatalf("markdown status missing for %s", status)
+			}
+		})
+	}
+}
+
+func TestAnalysisReportIsDeterministic(t *testing.T) {
+	firstOutput, err := JSON(provenAnalysis())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := provenAnalysis()
+	second.CausalFactors = []string{"workspace:config.txt"}
+	second.EvidenceBoundaries = []string{"host scheduling was not controlled"}
+	second.Limitations = []string{"proof applies only to the supported intervention model"}
+	secondOutput, err := JSON(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstOutput) != string(secondOutput) {
+		t.Fatalf("report changed for equivalent inputs:\n%s\n%s", firstOutput, secondOutput)
 	}
 }

--- a/internal/report/testdata/status_correlated.md
+++ b/internal/report/testdata/status_correlated.md
@@ -1,0 +1,21 @@
+# WorldBisect diagnosis
+
+**Status:** `CORRELATED`
+
+The detected difference appeared together with the failure, but WorldBisect could not safely change it independently. It is a lead for investigation, not a confirmed cause.
+## Proof
+
+- Forward intervention verified: `false`
+- Reverse intervention verified: `false`
+- Minimal within tested model: `false`
+
+## Confirmed or suspected cause
+
+No cause was confirmed within the supported test model.
+
+## Next steps
+1. Read the Limitations and Evidence boundaries sections below.
+2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
+3. Run the comparison again after removing uncontrolled differences where possible.
+
+<sub>Analysis `ana_correlated`; experiments: 0; factors: 0.</sub>

--- a/internal/report/testdata/status_proven.md
+++ b/internal/report/testdata/status_proven.md
@@ -1,0 +1,21 @@
+# WorldBisect diagnosis
+
+**Status:** `PROVEN`
+
+The failing run was repaired by changing the detected factor, and the failure returned when that change was reversed. The factor was also minimal within the tested model.
+## Proof
+
+- Forward intervention verified: `false`
+- Reverse intervention verified: `false`
+- Minimal within tested model: `false`
+
+## Confirmed or suspected cause
+
+No cause was confirmed within the supported test model.
+
+## Next steps
+1. Read the Limitations and Evidence boundaries sections below.
+2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
+3. Run the comparison again after removing uncontrolled differences where possible.
+
+<sub>Analysis `ana_proven`; experiments: 0; factors: 0.</sub>

--- a/internal/report/testdata/status_supported.md
+++ b/internal/report/testdata/status_supported.md
@@ -1,0 +1,21 @@
+# WorldBisect diagnosis
+
+**Status:** `SUPPORTED`
+
+The detected factor repaired the failure in the forward test, but the reverse or minimality proof was incomplete. Treat it as the best current lead, not as final proof.
+## Proof
+
+- Forward intervention verified: `false`
+- Reverse intervention verified: `false`
+- Minimal within tested model: `false`
+
+## Confirmed or suspected cause
+
+No cause was confirmed within the supported test model.
+
+## Next steps
+1. Read the Limitations and Evidence boundaries sections below.
+2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
+3. Run the comparison again after removing uncontrolled differences where possible.
+
+<sub>Analysis `ana_supported`; experiments: 0; factors: 0.</sub>

--- a/internal/report/testdata/status_unproven.md
+++ b/internal/report/testdata/status_unproven.md
@@ -1,0 +1,21 @@
+# WorldBisect diagnosis
+
+**Status:** `UNPROVEN`
+
+The available evidence was not sufficient to make a sound causal claim. Review the limitations and collect more controlled captures.
+## Proof
+
+- Forward intervention verified: `false`
+- Reverse intervention verified: `false`
+- Minimal within tested model: `false`
+
+## Confirmed or suspected cause
+
+No cause was confirmed within the supported test model.
+
+## Next steps
+1. Read the Limitations and Evidence boundaries sections below.
+2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
+3. Run the comparison again after removing uncontrolled differences where possible.
+
+<sub>Analysis `ana_unproven`; experiments: 0; factors: 0.</sub>

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -43,9 +43,12 @@ python3 - "$work/analysis.json" <<'PY'
 import json, sys
 value=json.load(open(sys.argv[1]))
 assert value["status"] == "PROVEN", value
-assert len(value["causal_factors"]) == 1, value
-factors={item["id"]: item for item in value["factors"]}
-assert factors[value["causal_factors"][0]]["key"] == "config.txt", value
+assert value["schema_version"] == 1, value
+assert value["format"] == "worldbisect.analysis-report.v1", value
+assert value["proof"] == {"forward_verified": True, "reverse_verified": True, "minimal_in_model": True}, value
+assert len(value["cause"]) == 1, value
+assert value["cause"][0]["key"] == "config.txt", value
+assert "boundaries" in value and "limitations" in value, value
 PY
 "$work/bin/worldbisect" verify "$work/result.wbc" > "$work/verify.json"
 python3 - "$work/verify.json" <<'PY'


### PR DESCRIPTION
## Summary

Implements #9 with stable operator-facing Markdown and machine-readable JSON reports.

## Included

- Stable GitHub-ready Markdown from one shared report model.
- Versioned worldbisect.analysis-report.v1 JSON contract.
- Explicit status, proof, cause, evidence-boundary, limitation, next-step, and evidence fields.
- Secret-safe output that omits captured command output and factor values.
- Contract and status snapshot tests for PROVEN, SUPPORTED, CORRELATED, and UNPROVEN.
- Updated end-to-end validation and operator documentation.

## Validation

- go test ./... -count=1
- go vet ./...
- ./scripts/e2e.sh
- Report snapshot and contract tests

Closes #9