### PR TITLE
feat(bundle): add verified diagnostic handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ Markdown output is also stable and can be pasted into GitHub pull requests or
 support tickets. Both formats are derived from the same report model and omit
 captured command output and factor values.
 
+Create a redacted diagnostic handoff for another engineer or support:
+
+```bash
+worldbisect export --store /tmp/worldbisect-store \
+  --analysis <analysis-id> --output diagnosis.wdiag
+worldbisect import --store /tmp/receiving-store \
+  --certificate-output imported.wbc diagnosis.wdiag
+worldbisect explain --store /tmp/receiving-store <analysis-id>
+worldbisect verify imported.wbc
+```
+
+Diagnostic bundles are deterministic and contain the analysis, both redacted
+captures, signed certificate, Markdown report, JSON report, and checksummed
+manifest. Raw command output, workspace content blobs, and secret-looking
+values are intentionally excluded.
+
 ## Commands
 
 ```text
@@ -136,7 +152,7 @@ worldbisect capture     Capture a command and its bounded runtime world
 worldbisect compare     Compare good and bad sessions and run interventions
 worldbisect explain     Render a stored analysis
 worldbisect export      Create a deterministic portable bundle
-worldbisect import      Import a validated bundle
+worldbisect import      Import a validated capture or diagnostic bundle
 worldbisect verify      Verify a causal certificate
 worldbisect audit       Verify the local audit chain
 worldbisect doctor      Validate host capabilities and configuration

--- a/cmd/worldbisect/main.go
+++ b/cmd/worldbisect/main.go
@@ -297,15 +297,29 @@ func runExport(args []string, stdout io.Writer) error {
 	set.SetOutput(io.Discard)
 	storePath := set.String("store", defaultStore(), "store directory")
 	output := set.String("output", "", "output path")
+	analysisID := set.String("analysis", "", "analysis ID for a redacted diagnostic bundle")
 	if err := set.Parse(args); err != nil {
 		return err
 	}
-	if set.NArg() != 1 || *output == "" {
+	if *output == "" {
 		return errors.New("entity ID and --output are required")
 	}
 	dataStore, err := openStore(*storePath)
 	if err != nil {
 		return err
+	}
+	if *analysisID != "" {
+		if set.NArg() != 0 {
+			return errors.New("do not provide an entity ID with --analysis")
+		}
+		if err := artifact.ExportDiagnostic(dataStore, *analysisID, *output); err != nil {
+			return err
+		}
+		fmt.Fprintln(stdout, *output)
+		return nil
+	}
+	if set.NArg() != 1 {
+		return errors.New("entity ID and --output are required")
 	}
 	if err := artifact.ExportCapture(dataStore, set.Arg(0), *output); err != nil {
 		return err
@@ -318,6 +332,7 @@ func runImport(args []string, stdout io.Writer) error {
 	set := flag.NewFlagSet("import", flag.ContinueOnError)
 	set.SetOutput(io.Discard)
 	storePath := set.String("store", defaultStore(), "store directory")
+	certificateOutput := set.String("certificate-output", "", "write an imported diagnostic certificate")
 	if err := set.Parse(args); err != nil {
 		return err
 	}
@@ -327,6 +342,17 @@ func runImport(args []string, stdout io.Writer) error {
 	dataStore, err := openStore(*storePath)
 	if err != nil {
 		return err
+	}
+	if id, certificate, diagnosticErr := artifact.ImportDiagnostic(dataStore, set.Arg(0)); diagnosticErr == nil {
+		if *certificateOutput != "" {
+			if err := os.WriteFile(*certificateOutput, certificate, 0o644); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintln(stdout, id)
+		return nil
+	} else if !errors.Is(diagnosticErr, artifact.ErrNotDiagnosticBundle) {
+		return diagnosticErr
 	}
 	id, err := artifact.ImportBundle(dataStore, set.Arg(0))
 	if err != nil {

--- a/docs/man/worldbisect.1
+++ b/docs/man/worldbisect.1
@@ -38,9 +38,14 @@ explicit Markdown output or B--format jsonR for the versioned
 .TP
 .B export
 Create a deterministic portable capture bundle.
+.PP
+Use \fB--analysis ID --output diagnosis.wdiag\fR to create a redacted
+diagnostic handoff containing the analysis, captures, signed certificate,
+reports, and checksummed manifest.
 .TP
 .B import
-Import and validate a capture bundle.
+Import and validate a capture or diagnostic bundle. Use
+\fB--certificate-output PATH\fR to retain an imported diagnostic certificate.
 .TP
 .B verify
 Verify an Ed25519 causal certificate.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -118,6 +118,23 @@ worldbisect import --store /tmp/other-store capture.wcap
 
 Bundles are deterministic and validated on import. Treat them as sensitive until reviewed.
 
+For an engineer-to-engineer or support handoff, export an analysis bundle:
+
+```bash
+worldbisect export --store /tmp/wb-store \
+  --analysis <analysis-id> --output diagnosis.wdiag
+worldbisect import --store /tmp/receiving-store \
+  --certificate-output imported.wbc diagnosis.wdiag
+worldbisect explain --store /tmp/receiving-store <analysis-id>
+worldbisect verify imported.wbc
+```
+
+The diagnostic bundle contains the analysis, good and bad capture metadata,
+the signed certificate, and both stable report formats. Export redacts command
+output, workspace content blobs, command arguments, sensitive paths, and
+secret-looking environment values. Its manifest checks every entry and import
+validates the certificate and report before persistence.
+
 ## Verify certificate
 
 ```bash

--- a/internal/artifact/bundle_test.go
+++ b/internal/artifact/bundle_test.go
@@ -99,3 +99,109 @@ func TestImportRejectsTraversalAndLinks(t *testing.T) {
 		})
 	}
 }
+
+func TestDiagnosticBundleIsDeterministicRedactedAndVerifiable(t *testing.T) {
+	dataStore, err := store.Open(filepath.Join(t.TempDir(), "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := dataStore.PutBlob([]byte("API_TOKEN=supersecret\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	good := &model.Capture{
+		SchemaVersion: 3, ID: "capture-good", CreatedAt: time.Unix(1, 0).UTC(),
+		WorkspaceRoot: "/sensitive/workspace", Command: model.CommandSpec{
+			Arguments: []string{"./check.sh", "supersecret"}, Directory: "/sensitive/workspace",
+			Environment: map[string]string{"API_TOKEN": "supersecret", "MODE": "good"},
+		}, Result: model.ProcessResult{Stdout: "supersecret output", Stderr: "secret error"},
+		Workspace: model.WorkspaceManifest{Entries: []model.WorkspaceEntry{{Path: "config.txt", Type: "file", BlobDigest: blob, Digest: blob}}},
+	}
+	bad := *good
+	bad.ID = "capture-bad"
+	bad.Result.Stdout = "bad supersecret output"
+	analysis := &model.Analysis{
+		SchemaVersion: 3, ID: "analysis-diagnostic", CreatedAt: time.Unix(2, 0).UTC(),
+		GoodCaptureID: good.ID, BadCaptureID: bad.ID, Status: model.StatusProven,
+		CausalFactors: []string{"workspace:config.txt"}, Factors: []model.Factor{{
+			ID: "workspace:config.txt", Type: model.FactorWorkspace, Key: "config.txt",
+			GoodValue: "supersecret", BadValue: "othersecret", GoodEntry: model.WorkspaceEntry{BlobDigest: blob},
+		}},
+	}
+	if err := dataStore.SaveCapture(good); err != nil {
+		t.Fatal(err)
+	}
+	if err := dataStore.SaveCapture(&bad); err != nil {
+		t.Fatal(err)
+	}
+	if err := dataStore.SaveAnalysis(analysis); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(t.TempDir(), "first.wdiag")
+	second := filepath.Join(t.TempDir(), "second.wdiag")
+	if err := ExportDiagnostic(dataStore, analysis.ID, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := ExportDiagnostic(dataStore, analysis.ID, second); err != nil {
+		t.Fatal(err)
+	}
+	firstBytes, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBytes, err := os.ReadFile(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatal("diagnostic bundle is not deterministic")
+	}
+	if bytes.Contains(firstBytes, []byte("supersecret")) || bytes.Contains(firstBytes, []byte("othersecret")) {
+		t.Fatal("diagnostic bundle contains unredacted secret material")
+	}
+
+	importStore, err := store.Open(filepath.Join(t.TempDir(), "import"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, certificate, err := ImportDiagnostic(importStore, first)
+	if err != nil || id != analysis.ID {
+		t.Fatalf("diagnostic import = %s, %v", id, err)
+	}
+	certificatePath := filepath.Join(t.TempDir(), "result.wbc")
+	if err := os.WriteFile(certificatePath, certificate, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	verified, err := VerifyCertificate(certificatePath, "")
+	if err != nil || !verified.Valid || verified.AnalysisID != analysis.ID {
+		t.Fatalf("offline certificate verification failed: %+v %v", verified, err)
+	}
+	imported, err := importStore.LoadAnalysis(analysis.ID)
+	if err != nil || imported.Status != model.StatusProven {
+		t.Fatalf("imported analysis unavailable: %+v %v", imported, err)
+	}
+	if _, err := importStore.GetBlob(blob); err == nil {
+		t.Fatal("diagnostic import unexpectedly restored raw workspace blob")
+	}
+}
+
+func TestDiagnosticImportRejectsUnsafeArchive(t *testing.T) {
+	bundle := filepath.Join(t.TempDir(), "unsafe.wdiag")
+	file, err := os.Create(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: "../escape", Mode: 0o644, Size: 1, Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = tarWriter.Write([]byte("x"))
+	_ = tarWriter.Close()
+	_ = gzipWriter.Close()
+	_ = file.Close()
+	dataStore, _ := store.Open(filepath.Join(t.TempDir(), "store"))
+	if _, _, err := ImportDiagnostic(dataStore, bundle); err == nil {
+		t.Fatal("expected unsafe diagnostic archive rejection")
+	}
+}

--- a/internal/artifact/certificate.go
+++ b/internal/artifact/certificate.go
@@ -38,21 +38,9 @@ func WriteCertificate(dataStore *store.Store, analysisID, output string) error {
 	if err != nil {
 		return err
 	}
-	privateKey, publicKey, err := loadOrCreateSigningKey(dataStore.Root())
+	certificate, err := certificateForAnalysis(dataStore, analysis)
 	if err != nil {
 		return err
-	}
-	payload, err := json.Marshal(analysis)
-	if err != nil {
-		return err
-	}
-	signature := ed25519.Sign(privateKey, payload)
-	certificate := Certificate{
-		Format:      "worldbisect.causal-certificate.v1",
-		Payload:     *analysis,
-		PublicKey:   base64.RawStdEncoding.EncodeToString(publicKey),
-		Signature:   base64.RawStdEncoding.EncodeToString(signature),
-		GeneratedAt: time.Now().UTC(),
 	}
 	encoded, err := json.MarshalIndent(certificate, "", "  ")
 	if err != nil {
@@ -60,6 +48,25 @@ func WriteCertificate(dataStore *store.Store, analysisID, output string) error {
 	}
 	encoded = append(encoded, '\n')
 	return atomicWriteFile(output, encoded, 0o644)
+}
+
+func certificateForAnalysis(dataStore *store.Store, analysis *model.Analysis) (Certificate, error) {
+	privateKey, publicKey, err := loadOrCreateSigningKey(dataStore.Root())
+	if err != nil {
+		return Certificate{}, err
+	}
+	payload, err := json.Marshal(analysis)
+	if err != nil {
+		return Certificate{}, err
+	}
+	signature := ed25519.Sign(privateKey, payload)
+	return Certificate{
+		Format:      "worldbisect.causal-certificate.v1",
+		Payload:     *analysis,
+		PublicKey:   base64.RawStdEncoding.EncodeToString(publicKey),
+		Signature:   base64.RawStdEncoding.EncodeToString(signature),
+		GeneratedAt: analysis.CreatedAt,
+	}, nil
 }
 
 func VerifyCertificate(path, publicKeyPath string) (VerificationResult, error) {

--- a/internal/artifact/diagnostic.go
+++ b/internal/artifact/diagnostic.go
@@ -1,0 +1,408 @@
+package artifact
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/ClusterPilot-System/worldbisect/internal/model"
+	"github.com/ClusterPilot-System/worldbisect/internal/redact"
+	"github.com/ClusterPilot-System/worldbisect/internal/report"
+	"github.com/ClusterPilot-System/worldbisect/internal/store"
+)
+
+const diagnosticBundleFormat = "worldbisect.diagnostic.v1"
+
+var ErrNotDiagnosticBundle = errors.New("not a diagnostic bundle")
+
+type diagnosticManifest struct {
+	Format        string            `json:"format"`
+	SchemaVersion int               `json:"schema_version"`
+	AnalysisID    string            `json:"analysis_id"`
+	CreatedAt     string            `json:"created_at"`
+	Entries       []diagnosticEntry `json:"entries"`
+}
+
+type diagnosticEntry struct {
+	Path   string `json:"path"`
+	Size   int64  `json:"size"`
+	Digest string `json:"digest"`
+}
+
+const (
+	maxDiagnosticEntries = 32
+	maxDiagnosticTotal   = 128 << 20
+)
+
+// ExportDiagnostic writes a deterministic, redacted handoff for an analysis.
+// It intentionally contains metadata and evidence references, not raw output or
+// workspace content, because those may contain customer secrets.
+func ExportDiagnostic(dataStore *store.Store, analysisID, output string) error {
+	analysis, err := dataStore.LoadAnalysis(analysisID)
+	if err != nil {
+		return err
+	}
+	if analysis.GoodCaptureID == "" || analysis.BadCaptureID == "" {
+		return errors.New("analysis does not reference both good and bad captures")
+	}
+	good, err := dataStore.LoadCapture(analysis.GoodCaptureID)
+	if err != nil {
+		return err
+	}
+	bad, err := dataStore.LoadCapture(analysis.BadCaptureID)
+	if err != nil {
+		return err
+	}
+	redactedAnalysis := redactAnalysis(analysis)
+	redactedGood := redactCapture(good)
+	redactedBad := redactCapture(bad)
+
+	certificate, err := certificateForAnalysis(dataStore, redactedAnalysis)
+	if err != nil {
+		return err
+	}
+	certificateBytes, err := canonicalJSON(certificate)
+	if err != nil {
+		return err
+	}
+	analysisBytes, err := canonicalJSON(redactedAnalysis)
+	if err != nil {
+		return err
+	}
+	goodBytes, err := canonicalJSON(redactedGood)
+	if err != nil {
+		return err
+	}
+	badBytes, err := canonicalJSON(redactedBad)
+	if err != nil {
+		return err
+	}
+	reportJSON, err := report.JSON(redactedAnalysis)
+	if err != nil {
+		return err
+	}
+	reportMarkdown := []byte(report.Markdown(redactedAnalysis))
+
+	entries := []archiveEntry{
+		{Name: "analysis.json", Content: analysisBytes},
+		{Name: "captures/bad.json", Content: badBytes},
+		{Name: "captures/good.json", Content: goodBytes},
+		{Name: "certificate.json", Content: certificateBytes},
+		{Name: "report.json", Content: reportJSON},
+		{Name: "report.md", Content: reportMarkdown},
+	}
+	manifest := diagnosticManifest{
+		Format: diagnosticBundleFormat, SchemaVersion: 1, AnalysisID: redactedAnalysis.ID,
+		CreatedAt: redactedAnalysis.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+	}
+	for _, entry := range entries {
+		manifest.Entries = append(manifest.Entries, diagnosticEntry{Path: entry.Name, Size: int64(len(entry.Content)), Digest: digest(entry.Content)})
+	}
+	manifestBytes, err := canonicalJSON(manifest)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, archiveEntry{Name: "manifest.json", Content: manifestBytes})
+	return writeDeterministicTarGzip(output, entries)
+}
+
+// ImportDiagnostic validates every declared byte before persisting any entity.
+// The returned certificate is already verified and can be written for offline use.
+func ImportDiagnostic(dataStore *store.Store, bundlePath string) (string, []byte, error) {
+	entries, err := readDiagnosticArchive(bundlePath)
+	if err != nil {
+		return "", nil, err
+	}
+	manifestBytes, ok := entries["manifest.json"]
+	if !ok {
+		return "", nil, ErrNotDiagnosticBundle
+	}
+	var envelope struct {
+		Format string `json:"format"`
+	}
+	if err := json.Unmarshal(manifestBytes, &envelope); err != nil || envelope.Format != diagnosticBundleFormat {
+		return "", nil, ErrNotDiagnosticBundle
+	}
+	var manifest diagnosticManifest
+	decoder := json.NewDecoder(bytes.NewReader(manifestBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return "", nil, fmt.Errorf("decode diagnostic manifest: %w", err)
+	}
+	if manifest.Format != diagnosticBundleFormat {
+		return "", nil, ErrNotDiagnosticBundle
+	}
+	if manifest.SchemaVersion != 1 || !validDiagnosticID(manifest.AnalysisID) || len(manifest.Entries) != 6 {
+		return "", nil, errors.New("invalid diagnostic manifest")
+	}
+	declared := make(map[string]diagnosticEntry, len(manifest.Entries))
+	for _, item := range manifest.Entries {
+		if err := validateArchiveName(item.Path); err != nil || item.Size < 0 || item.Size > maxEntityBytes || !validDigest(item.Digest) {
+			return "", nil, errors.New("invalid diagnostic entry")
+		}
+		if _, exists := declared[item.Path]; exists || item.Path == "manifest.json" {
+			return "", nil, errors.New("duplicate diagnostic entry")
+		}
+		declared[item.Path] = item
+		content, exists := entries[item.Path]
+		if !exists || int64(len(content)) != item.Size || digest(content) != item.Digest {
+			return "", nil, fmt.Errorf("diagnostic entry %s failed validation", item.Path)
+		}
+	}
+	if len(entries) != len(declared)+1 {
+		return "", nil, errors.New("unexpected diagnostic archive entry")
+	}
+	for name := range entries {
+		if name != "manifest.json" {
+			if _, exists := declared[name]; !exists {
+				return "", nil, fmt.Errorf("unexpected diagnostic archive entry %q", name)
+			}
+		}
+	}
+
+	var analysis model.Analysis
+	if err := decodeStrict(entries["analysis.json"], &analysis); err != nil {
+		return "", nil, fmt.Errorf("decode diagnostic analysis: %w", err)
+	}
+	if analysis.ID != manifest.AnalysisID {
+		return "", nil, errors.New("diagnostic analysis ID does not match manifest")
+	}
+	var good, bad model.Capture
+	if err := decodeStrict(entries["captures/good.json"], &good); err != nil {
+		return "", nil, fmt.Errorf("decode good capture: %w", err)
+	}
+	if err := decodeStrict(entries["captures/bad.json"], &bad); err != nil {
+		return "", nil, fmt.Errorf("decode bad capture: %w", err)
+	}
+	if good.ID != analysis.GoodCaptureID || bad.ID != analysis.BadCaptureID {
+		return "", nil, errors.New("diagnostic capture references do not match analysis")
+	}
+	var certificate Certificate
+	if err := decodeStrict(entries["certificate.json"], &certificate); err != nil {
+		return "", nil, fmt.Errorf("decode diagnostic certificate: %w", err)
+	}
+	if result := verifyCertificateValue(certificate, &analysis); !result.Valid {
+		return "", nil, fmt.Errorf("diagnostic certificate is invalid: %s", result.Error)
+	}
+	var structured report.AnalysisReport
+	if err := decodeStrict(entries["report.json"], &structured); err != nil {
+		return "", nil, fmt.Errorf("decode diagnostic report: %w", err)
+	}
+	if structured.SchemaVersion != report.AnalysisReportSchemaVersion || structured.Format != "worldbisect.analysis-report.v1" || structured.AnalysisID != analysis.ID || structured.Status != string(analysis.Status) {
+		return "", nil, errors.New("diagnostic report does not match analysis")
+	}
+	if !bytes.HasPrefix(entries["report.md"], []byte("# WorldBisect diagnosis\n")) {
+		return "", nil, errors.New("diagnostic Markdown report is invalid")
+	}
+
+	if err := dataStore.SaveCapture(&good); err != nil {
+		return "", nil, err
+	}
+	if err := dataStore.SaveCapture(&bad); err != nil {
+		return "", nil, err
+	}
+	if err := dataStore.SaveAnalysis(&analysis); err != nil {
+		return "", nil, err
+	}
+	if err := dataStore.AppendAudit("diagnostic-import", "analysis", analysis.ID, map[string]any{"format": diagnosticBundleFormat}); err != nil {
+		return "", nil, err
+	}
+	return analysis.ID, append([]byte(nil), entries["certificate.json"]...), nil
+}
+
+func readDiagnosticArchive(bundlePath string) (map[string][]byte, error) {
+	info, err := os.Stat(bundlePath)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxBundleBytes {
+		return nil, fmt.Errorf("bundle exceeds %d bytes", maxBundleBytes)
+	}
+	file, err := os.Open(bundlePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	gzipReader, err := gzip.NewReader(io.LimitReader(file, maxBundleBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+	entries := make(map[string][]byte)
+	var total int64
+	tarReader := tar.NewReader(gzipReader)
+	for count := 0; ; count++ {
+		if count >= maxDiagnosticEntries {
+			return nil, errors.New("diagnostic archive entry limit exceeded")
+		}
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := validateArchiveHeader(header); err != nil {
+			return nil, err
+		}
+		if _, exists := entries[header.Name]; exists {
+			return nil, fmt.Errorf("duplicate archive entry %q", header.Name)
+		}
+		if header.Size > maxEntityBytes {
+			return nil, fmt.Errorf("entry %q exceeds limit", header.Name)
+		}
+		total += header.Size
+		if total > maxDiagnosticTotal {
+			return nil, errors.New("diagnostic archive exceeds total size limit")
+		}
+		content, err := io.ReadAll(io.LimitReader(tarReader, maxEntityBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(content)) != header.Size {
+			return nil, fmt.Errorf("entry %q has invalid size", header.Name)
+		}
+		entries[header.Name] = content
+	}
+	return entries, nil
+}
+
+func decodeStrict(content []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(value)
+}
+
+func redactAnalysis(value *model.Analysis) *model.Analysis {
+	copy := cloneAnalysis(value)
+	for index := range copy.Factors {
+		factor := &copy.Factors[index]
+		factor.GoodValue = ""
+		factor.BadValue = ""
+		factor.GoodEntry.Digest = ""
+		factor.GoodEntry.BlobDigest = ""
+		factor.BadEntry.Digest = ""
+		factor.BadEntry.BlobDigest = ""
+		if redact.LooksSecret(factor.Key) {
+			factor.Key = "[redacted factor]"
+		}
+	}
+	for index := range copy.Experiments {
+		experiment := &copy.Experiments[index]
+		experiment.Result.Stdout = ""
+		experiment.Result.Stderr = ""
+		experiment.Result.ConsultedPaths = nil
+		experiment.Error = ""
+	}
+	return copy
+}
+
+func redactCapture(value *model.Capture) *model.Capture {
+	copy := cloneCapture(value)
+	copy.WorkspaceRoot = "[redacted]"
+	copy.Command.Directory = "[redacted]"
+	copy.Command.Arguments = []string{"[redacted from diagnostic bundle]"}
+	copy.Command.Environment = redactEnvironment(copy.Command.Environment)
+	copy.Oracle.Pattern = ""
+	copy.Oracle.File = ""
+	copy.Oracle.Digest = ""
+	copy.Result.Stdout = ""
+	copy.Result.Stderr = ""
+	copy.Result.ConsultedPaths = nil
+	copy.Host.Hostname = ""
+	copy.ConsultedPaths = nil
+	redactManifest(&copy.Before)
+	redactManifest(&copy.Workspace)
+	return copy
+}
+
+func redactManifest(value *model.WorkspaceManifest) {
+	value.Root = "[redacted]"
+	value.Digest = ""
+	for index := range value.Entries {
+		entry := &value.Entries[index]
+		entry.Digest = ""
+		entry.BlobDigest = ""
+		if redact.LooksSecret(entry.Path) {
+			entry.Path = "[redacted path]"
+		}
+	}
+}
+
+func redactEnvironment(values map[string]string) map[string]string {
+	result := make(map[string]string, len(values))
+	for name, value := range values {
+		if redact.LooksSecret(name) {
+			result[name] = "[redacted]"
+		} else {
+			result[name] = value
+		}
+	}
+	return result
+}
+
+func cloneAnalysis(value *model.Analysis) *model.Analysis {
+	encoded, _ := json.Marshal(value)
+	var copy model.Analysis
+	_ = json.Unmarshal(encoded, &copy)
+	return &copy
+}
+
+func cloneCapture(value *model.Capture) *model.Capture {
+	encoded, _ := json.Marshal(value)
+	var copy model.Capture
+	_ = json.Unmarshal(encoded, &copy)
+	return &copy
+}
+
+func validDiagnosticID(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '-' || char == '_' || char == '.' {
+			continue
+		}
+		return false
+	}
+	return !strings.Contains(value, "..")
+}
+
+func verifyCertificateValue(certificate Certificate, analysis *model.Analysis) VerificationResult {
+	if certificate.Format != "worldbisect.causal-certificate.v1" || certificate.Payload.ID != analysis.ID {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate identity mismatch"}
+	}
+	if certificate.Payload.Status != analysis.Status {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate status mismatch"}
+	}
+	key, err := base64.RawStdEncoding.DecodeString(certificate.PublicKey)
+	if err != nil || len(key) != ed25519.PublicKeySize {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "invalid embedded public key"}
+	}
+	signature, err := base64.RawStdEncoding.DecodeString(certificate.Signature)
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "invalid certificate signature"}
+	}
+	payload, err := json.Marshal(certificate.Payload)
+	if err != nil {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate payload could not be encoded"}
+	}
+	expected, err := json.Marshal(analysis)
+	if err != nil || !bytes.Equal(payload, expected) {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate payload does not match analysis"}
+	}
+	valid := ed25519.Verify(ed25519.PublicKey(key), payload, signature)
+	result := VerificationResult{Valid: valid, AnalysisID: analysis.ID, Status: string(analysis.Status)}
+	if !valid {
+		result.Error = "signature verification failed"
+	}
+	return result
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -215,7 +215,8 @@ func nextSteps(value *model.Analysis) []string {
 		}
 	}
 
-	steps := make([]string, 0, len(value.CausalFactors)+3)
+	// Avoid deriving an allocation capacity from untrusted collection lengths.
+	steps := make([]string, 0)
 	byID := make(map[string]model.Factor, len(value.Factors))
 	for _, factor := range value.Factors {
 		byID[factor.ID] = factor

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -50,6 +50,21 @@ assert len(value["cause"]) == 1, value
 assert value["cause"][0]["key"] == "config.txt", value
 assert "boundaries" in value and "limitations" in value, value
 PY
+analysis_id=$(python3 - "$work/analysis.json" <<'PY'
+import json, sys
+print(json.load(open(sys.argv[1]))["analysis_id"])
+PY
+)
+diagnostic_store="$work/diagnostic-store"
+"$work/bin/worldbisect" export --store "$store" --analysis "$analysis_id" --output "$work/diagnosis.wdiag" >/dev/null
+"$work/bin/worldbisect" import --store "$diagnostic_store" --certificate-output "$work/imported.wbc" "$work/diagnosis.wdiag" >/dev/null
+"$work/bin/worldbisect" explain --store "$diagnostic_store" "$analysis_id" >/dev/null
+"$work/bin/worldbisect" verify "$work/imported.wbc" > "$work/imported-verify.json"
+python3 - "$work/imported-verify.json" <<'PY'
+import json, sys
+value=json.load(open(sys.argv[1]))
+assert value["valid"] is True, value
+PY
 "$work/bin/worldbisect" verify "$work/result.wbc" > "$work/verify.json"
 python3 - "$work/verify.json" <<'PY'
 import json, sys


### PR DESCRIPTION
## Summary

Implements #10 with a deterministic, redacted diagnostic handoff bundle.

## Included

- New .wdiag bundle containing analysis, both captures, signed certificate, Markdown report, JSON report, and checksummed manifest.
- Redaction before export: command output, workspace blobs, command arguments, sensitive paths, and secret-looking values are excluded.
- Strict offline validation of archive paths, types, duplicates, sizes, checksums, schema, certificate, and report consistency before persistence.
- Existing .wcap capture bundles remain supported.
- CLI export/import workflow with offline xplain and erify support.
- Determinism, redaction, traversal, duplicate, and certificate regression tests.

## Validation

- go test ./... -count=1
- go vet ./...
- ./scripts/e2e.sh
- git diff --check

Closes #10