### PR TITLE
feat(ci): add JUnit and SARIF diagnostic output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,16 @@ jobs:
       - name: End-to-end
         env:
           WORLDBISECT_E2E_RACE: "1"
+          WORLDBISECT_E2E_ARTIFACT_DIR: build/diagnostics
         run: timeout --foreground 120s ./scripts/e2e.sh
+      - name: Upload diagnostic reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: worldbisect-diagnostic-reports
+          path: build/diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Release gate
         run: make check
       - name: Upload test artifacts
@@ -51,6 +60,24 @@ jobs:
             coverage.out
           if-no-files-found: ignore
           retention-days: 7
+
+  upload-diagnostic-sarif:
+    if: github.event_name != 'pull_request' && needs.validate.result == 'success'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      security-events: write
+    steps:
+      - name: Download diagnostic reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: worldbisect-diagnostic-reports
+          path: build/diagnostics
+      - name: Upload SARIF findings
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: build/diagnostics/analysis.sarif
 
   arm64-runtime:
     runs-on: ubuntu-22.04-arm

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ captures, signed certificate, Markdown report, JSON report, and checksummed
 manifest. Raw command output, workspace content blobs, and secret-looking
 values are intentionally excluded.
 
+For CI integrations, `compare` and `explain` also support `--format junit` and
+`--format sarif`. JUnit marks `PROVEN` and `SUPPORTED` as failures and the
+other statuses as explicit skips. SARIF emits an `error` for `PROVEN`, a
+`warning` for `SUPPORTED` or `CORRELATED`, and a `note` for `UNPROVEN`.
+Formatting alone exits with code `0`; use `--fail-on proven`, `supported`,
+`correlated`, or `any` to make selected statuses exit with code `1`.
+
 ## Commands
 
 ```text

--- a/cmd/worldbisect/main.go
+++ b/cmd/worldbisect/main.go
@@ -196,8 +196,11 @@ func runCompare(args []string, stdout io.Writer) error {
 	bad := set.String("bad", "", "bad capture ID or bundle")
 	repetitions := set.Int("repetitions", 3, "experiment repetitions")
 	maxExperiments := set.Int("max-experiments", 128, "experiment budget")
-	format := set.String("format", "text", "text or json")
+	format := set.String("format", "text", "text, json, junit, or sarif")
 	certificate := set.String("certificate", "", "certificate output path")
+	reportURL := set.String("report-url", "", "stable URL for the report")
+	bundleURL := set.String("bundle-url", "", "stable URL for the diagnostic bundle")
+	failOn := set.String("fail-on", "never", "exit 1 for never, proven, supported, correlated, or any")
 	if err := set.Parse(flags); err != nil {
 		return err
 	}
@@ -241,7 +244,7 @@ func runCompare(args []string, stdout io.Writer) error {
 		}
 	}
 	if analysis != nil {
-		return writeAnalysis(stdout, analysis, *format)
+		return finishAnalysis(stdout, analysis, *format, report.OutputLinks{ReportURL: *reportURL, BundleURL: *bundleURL}, *failOn)
 	}
 	return err
 }
@@ -257,7 +260,10 @@ func runExplain(args []string, stdout io.Writer) error {
 	set := flag.NewFlagSet("explain", flag.ContinueOnError)
 	set.SetOutput(io.Discard)
 	storePath := set.String("store", defaultStore(), "store directory")
-	format := set.String("format", "text", "text or json")
+	format := set.String("format", "text", "text, json, junit, or sarif")
+	reportURL := set.String("report-url", "", "stable URL for the report")
+	bundleURL := set.String("bundle-url", "", "stable URL for the diagnostic bundle")
+	failOn := set.String("fail-on", "never", "exit 1 for never, proven, supported, correlated, or any")
 	if err := set.Parse(args); err != nil {
 		return err
 	}
@@ -272,10 +278,24 @@ func runExplain(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return writeAnalysis(stdout, analysis, *format)
+	return finishAnalysis(stdout, analysis, *format, report.OutputLinks{ReportURL: *reportURL, BundleURL: *bundleURL}, *failOn)
 }
 
-func writeAnalysis(stdout io.Writer, analysis *model.Analysis, format string) error {
+func finishAnalysis(stdout io.Writer, analysis *model.Analysis, format string, links report.OutputLinks, failOn string) error {
+	if err := writeAnalysis(stdout, analysis, format, links); err != nil {
+		return err
+	}
+	fails, err := report.ShouldFail(analysis.Status, failOn)
+	if err != nil {
+		return err
+	}
+	if fails {
+		return fmt.Errorf("analysis status %s matched --fail-on %s", analysis.Status, failOn)
+	}
+	return nil
+}
+
+func writeAnalysis(stdout io.Writer, analysis *model.Analysis, format string, links report.OutputLinks) error {
 	switch format {
 	case "text", "markdown":
 		_, err := fmt.Fprint(stdout, report.Markdown(analysis))
@@ -287,8 +307,22 @@ func writeAnalysis(stdout io.Writer, analysis *model.Analysis, format string) er
 		}
 		_, err = stdout.Write(encoded)
 		return err
+	case "junit":
+		encoded, err := report.JUnit(analysis, links)
+		if err != nil {
+			return err
+		}
+		_, err = stdout.Write(encoded)
+		return err
+	case "sarif":
+		encoded, err := report.SARIF(analysis, links)
+		if err != nil {
+			return err
+		}
+		_, err = stdout.Write(encoded)
+		return err
 	default:
-		return fmt.Errorf("unsupported analysis format %q (use text, markdown, or json)", format)
+		return fmt.Errorf("unsupported analysis format %q (use text, markdown, junit, or sarif)", format)
 	}
 }
 

--- a/docs/man/worldbisect.1
+++ b/docs/man/worldbisect.1
@@ -46,6 +46,11 @@ reports, and checksummed manifest.
 .B import
 Import and validate a capture or diagnostic bundle. Use
 \fB--certificate-output PATH\fR to retain an imported diagnostic certificate.
+.PP
+Use \fB--format junit\fR or \fB--format sarif\fR with BcompareR or
+BexplainR for CI output. Formatting exits zero; use
+\fB--fail-on proven|supported|correlated|any\fR to make selected statuses exit
+one.
 .TP
 .B verify
 Verify an Ed25519 causal certificate.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -135,6 +135,24 @@ output, workspace content blobs, command arguments, sensitive paths, and
 secret-looking environment values. Its manifest checks every entry and import
 validates the certificate and report before persistence.
 
+## CI output and exit codes
+
+`compare` and `explain` support these machine-readable formats:
+
+```bash
+worldbisect explain --store /tmp/wb-store --format junit <analysis-id> > analysis.junit.xml
+worldbisect explain --store /tmp/wb-store --format sarif <analysis-id> > analysis.sarif
+```
+
+JUnit reports `PROVEN` and `SUPPORTED` as failures; `CORRELATED` and
+`UNPROVEN` are explicit skips. SARIF reports `PROVEN` as an error,
+`SUPPORTED`/`CORRELATED` as warnings, and `UNPROVEN` as a note. Report
+formatting exits `0` regardless of proof status. Add `--fail-on proven`,
+`--fail-on supported`, `--fail-on correlated`, or `--fail-on any` when the CI
+job must exit `1` for that status threshold. Operational errors always exit
+`1`. `--report-url` and `--bundle-url` add stable links to JUnit properties and
+SARIF result properties without embedding sensitive data.
+
 ## Verify certificate
 
 ```bash

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"sort"
 	"strings"
@@ -10,6 +11,88 @@ import (
 )
 
 const AnalysisReportSchemaVersion = 1
+
+type OutputLinks struct {
+	ReportURL string
+	BundleURL string
+}
+
+type junitTestSuites struct {
+	XMLName  xml.Name         `xml:"testsuites"`
+	Name     string           `xml:"name,attr"`
+	Tests    int              `xml:"tests,attr"`
+	Failures int              `xml:"failures,attr"`
+	Skipped  int              `xml:"skipped,attr"`
+	Suites   []junitTestSuite `xml:"testsuite"`
+}
+
+type junitTestSuite struct {
+	Name       string          `xml:"name,attr"`
+	Tests      int             `xml:"tests,attr"`
+	Failures   int             `xml:"failures,attr"`
+	Skipped    int             `xml:"skipped,attr"`
+	Properties []junitProperty `xml:"properties>property"`
+	Cases      []junitTestCase `xml:"testcase"`
+}
+
+type junitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type junitTestCase struct {
+	Classname string        `xml:"classname,attr"`
+	Name      string        `xml:"name,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+	Skipped   *junitSkipped `xml:"skipped,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Text    string `xml:",chardata"`
+}
+
+type junitSkipped struct {
+	Message string `xml:"message,attr"`
+}
+
+type sarifDocument struct {
+	Version string     `json:"version"`
+	Schema  string     `json:"$schema"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name  string      `json:"name"`
+	Rules []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID               string    `json:"id"`
+	Name             string    `json:"name"`
+	ShortDescription sarifText `json:"shortDescription"`
+	HelpURI          string    `json:"helpUri,omitempty"`
+}
+
+type sarifResult struct {
+	RuleID     string         `json:"ruleId"`
+	Level      string         `json:"level"`
+	Message    sarifText      `json:"message"`
+	Properties map[string]any `json:"properties"`
+}
+
+type sarifText struct {
+	Text string `json:"text"`
+}
 
 // AnalysisReport is the stable, secret-safe public representation of an analysis.
 // Keep this separate from model.Analysis so persisted internals can evolve without
@@ -107,6 +190,114 @@ func JSON(value *model.Analysis) ([]byte, error) {
 		return nil, err
 	}
 	return append(encoded, '\n'), nil
+}
+
+// JUnit returns a deterministic test result for CI systems that consume XML.
+// PROVEN and SUPPORTED are findings; CORRELATED and UNPROVEN are explicit skips.
+func JUnit(value *model.Analysis, links OutputLinks) ([]byte, error) {
+	report := Build(value)
+	caseValue := junitTestCase{Classname: "worldbisect.analysis", Name: report.AnalysisID}
+	properties := []junitProperty{
+		{Name: "analysis_id", Value: report.AnalysisID},
+		{Name: "status", Value: report.Status},
+		{Name: "schema_version", Value: fmt.Sprint(report.SchemaVersion)},
+	}
+	if links.ReportURL != "" {
+		properties = append(properties, junitProperty{Name: "report_url", Value: links.ReportURL})
+	}
+	if links.BundleURL != "" {
+		properties = append(properties, junitProperty{Name: "bundle_url", Value: links.BundleURL})
+	}
+	failures := 0
+	skipped := 0
+	if findingStatus(value.Status) {
+		failures = 1
+		caseValue.Failure = &junitFailure{Message: report.Status, Text: report.Explanation}
+	} else {
+		skipped = 1
+		caseValue.Skipped = &junitSkipped{Message: report.Status}
+	}
+	document := junitTestSuites{
+		Name: "WorldBisect", Tests: 1, Failures: failures, Skipped: skipped,
+		Suites: []junitTestSuite{{
+			Name: "worldbisect.analysis", Tests: 1, Failures: failures, Skipped: skipped,
+			Properties: properties, Cases: []junitTestCase{caseValue},
+		}},
+	}
+	encoded, err := xml.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"), append(encoded, '\n')...), nil
+}
+
+// SARIF returns a SARIF 2.1.0 finding suitable for GitHub code scanning upload.
+func SARIF(value *model.Analysis, links OutputLinks) ([]byte, error) {
+	report := Build(value)
+	ruleID := "worldbisect/" + report.Status
+	rule := sarifRule{
+		ID: ruleID, Name: "WorldBisect " + report.Status,
+		ShortDescription: sarifText{Text: report.Explanation},
+		HelpURI:          links.ReportURL,
+	}
+	properties := map[string]any{
+		"analysis_id":      report.AnalysisID,
+		"status":           report.Status,
+		"schema_version":   report.SchemaVersion,
+		"forward_verified": report.Proof.ForwardVerified,
+		"reverse_verified": report.Proof.ReverseVerified,
+		"minimal_in_model": report.Proof.MinimalInModel,
+	}
+	if links.BundleURL != "" {
+		properties["bundle_url"] = links.BundleURL
+	}
+	if links.ReportURL != "" {
+		properties["report_url"] = links.ReportURL
+	}
+	result := sarifResult{RuleID: ruleID, Level: sarifLevel(value.Status), Message: sarifText{Text: report.Explanation}, Properties: properties}
+	document := sarifDocument{
+		Version: "2.1.0",
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Runs:    []sarifRun{{Tool: sarifTool{Driver: sarifDriver{Name: "WorldBisect", Rules: []sarifRule{rule}}}, Results: []sarifResult{result}}},
+	}
+	encoded, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+// ShouldFail applies the documented CI policy without changing the report payload.
+func ShouldFail(status model.ProofStatus, policy string) (bool, error) {
+	switch policy {
+	case "never", "":
+		return false, nil
+	case "proven":
+		return status == model.StatusProven, nil
+	case "supported":
+		return status == model.StatusProven || status == model.StatusSupported, nil
+	case "correlated":
+		return status != model.StatusUnproven, nil
+	case "any":
+		return true, nil
+	default:
+		return false, fmt.Errorf("unsupported --fail-on value %q (use never, proven, supported, correlated, or any)", policy)
+	}
+}
+
+func findingStatus(status model.ProofStatus) bool {
+	return status == model.StatusProven || status == model.StatusSupported
+}
+
+func sarifLevel(status model.ProofStatus) string {
+	switch status {
+	case model.StatusProven:
+		return "error"
+	case model.StatusSupported, model.StatusCorrelated:
+		return "warning"
+	default:
+		return "note"
+	}
 }
 
 // Markdown returns a stable report suitable for GitHub comments and support tickets.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,5 +104,82 @@ func TestAnalysisReportIsDeterministic(t *testing.T) {
 	}
 	if string(firstOutput) != string(secondOutput) {
 		t.Fatalf("report changed for equivalent inputs:\n%s\n%s", firstOutput, secondOutput)
+	}
+}
+
+func TestJUnitAndSARIFContractsCoverStatuses(t *testing.T) {
+	for _, status := range []model.ProofStatus{model.StatusProven, model.StatusSupported, model.StatusCorrelated, model.StatusUnproven} {
+		t.Run(string(status), func(t *testing.T) {
+			value := &model.Analysis{ID: "ana_" + strings.ToLower(string(status)), Status: status, Summary: "do not expose supersecret"}
+			junit, err := JUnit(value, OutputLinks{ReportURL: "https://ci.example/report", BundleURL: "https://ci.example/bundle"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var suites struct {
+				Failures int `xml:"failures,attr"`
+				Skipped  int `xml:"skipped,attr"`
+			}
+			if err := xml.Unmarshal(junit, &suites); err != nil {
+				t.Fatalf("invalid JUnit: %v\n%s", err, junit)
+			}
+			if findingStatus(status) && suites.Failures != 1 {
+				t.Fatalf("JUnit failures = %d for %s", suites.Failures, status)
+			}
+			if !findingStatus(status) && suites.Skipped != 1 {
+				t.Fatalf("JUnit skipped = %d for %s", suites.Skipped, status)
+			}
+			sarif, err := SARIF(value, OutputLinks{ReportURL: "https://ci.example/report", BundleURL: "https://ci.example/bundle"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var document struct {
+				Version string `json:"version"`
+				Runs    []struct {
+					Results []struct {
+						RuleID     string         `json:"ruleId"`
+						Level      string         `json:"level"`
+						Properties map[string]any `json:"properties"`
+					} `json:"results"`
+				} `json:"runs"`
+			}
+			if err := json.Unmarshal(sarif, &document); err != nil {
+				t.Fatalf("invalid SARIF: %v\n%s", err, sarif)
+			}
+			if document.Version != "2.1.0" || len(document.Runs) != 1 || len(document.Runs[0].Results) != 1 {
+				t.Fatalf("invalid SARIF shape: %s", sarif)
+			}
+			result := document.Runs[0].Results[0]
+			if result.RuleID != "worldbisect/"+string(status) || result.Properties["status"] != string(status) {
+				t.Fatalf("invalid SARIF result: %s", sarif)
+			}
+			if strings.Contains(string(junit), "supersecret") || strings.Contains(string(sarif), "supersecret") {
+				t.Fatal("diagnostic formats exposed secret text")
+			}
+		})
+	}
+}
+
+func TestShouldFailIsDeterministic(t *testing.T) {
+	cases := []struct {
+		status model.ProofStatus
+		policy string
+		want   bool
+	}{
+		{model.StatusProven, "never", false},
+		{model.StatusProven, "proven", true},
+		{model.StatusSupported, "proven", false},
+		{model.StatusSupported, "supported", true},
+		{model.StatusCorrelated, "correlated", true},
+		{model.StatusUnproven, "correlated", false},
+		{model.StatusUnproven, "any", true},
+	}
+	for _, test := range cases {
+		got, err := ShouldFail(test.status, test.policy)
+		if err != nil || got != test.want {
+			t.Errorf("ShouldFail(%s, %s) = %t, %v; want %t", test.status, test.policy, got, err, test.want)
+		}
+	}
+	if _, err := ShouldFail(model.StatusProven, "invalid"); err == nil {
+		t.Fatal("invalid fail policy was accepted")
 	}
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -65,6 +65,21 @@ import json, sys
 value=json.load(open(sys.argv[1]))
 assert value["valid"] is True, value
 PY
+"$work/bin/worldbisect" explain --store "$store" --format junit --report-url https://ci.example/report --bundle-url https://ci.example/bundle "$analysis_id" > "$work/analysis.junit.xml"
+"$work/bin/worldbisect" explain --store "$store" --format sarif --report-url https://ci.example/report --bundle-url https://ci.example/bundle "$analysis_id" > "$work/analysis.sarif"
+if "$work/bin/worldbisect" explain --store "$store" --format sarif --fail-on proven "$analysis_id" > "$work/fail-on.sarif" 2> "$work/fail-on.err"; then
+  echo "--fail-on proven did not fail for PROVEN analysis" >&2
+  exit 1
+fi
+python3 - "$work/analysis.junit.xml" "$work/analysis.sarif" <<'PY'
+import json, sys, xml.etree.ElementTree as ET
+junit=ET.parse(sys.argv[1]).getroot()
+assert junit.attrib["failures"] == "1", junit.attrib
+sarif=json.load(open(sys.argv[2]))
+assert sarif["version"] == "2.1.0", sarif
+assert sarif["runs"][0]["results"][0]["ruleId"] == "worldbisect/PROVEN", sarif
+assert sarif["runs"][0]["results"][0]["properties"]["report_url"] == "https://ci.example/report", sarif
+PY
 "$work/bin/worldbisect" verify "$work/result.wbc" > "$work/verify.json"
 python3 - "$work/verify.json" <<'PY'
 import json, sys
@@ -77,6 +92,14 @@ import json, sys
 value=json.load(open(sys.argv[1]))
 assert value["valid"] is True, value
 PY
+
+if [[ -n "${WORLDBISECT_E2E_ARTIFACT_DIR:-}" ]]; then
+  mkdir -p "$WORLDBISECT_E2E_ARTIFACT_DIR"
+  cp "$work/analysis.json" "$WORLDBISECT_E2E_ARTIFACT_DIR/analysis.json"
+  cp "$work/analysis.junit.xml" "$WORLDBISECT_E2E_ARTIFACT_DIR/analysis.junit.xml"
+  cp "$work/analysis.sarif" "$WORLDBISECT_E2E_ARTIFACT_DIR/analysis.sarif"
+  cp "$work/diagnosis.wdiag" "$WORLDBISECT_E2E_ARTIFACT_DIR/diagnosis.wdiag"
+fi
 
 config="$work/config.json"
 init_output=$("$work/bin/worldbisectd" init --config "$config" --data-dir "$work/daemon-data" --listen 127.0.0.1:0)


### PR DESCRIPTION
## Summary

Implements #11 with deterministic CI outputs and documented proof-status exit policies.

## Included

- --format junit and --format sarif for compare and xplain.
- Secret-safe, versioned output contracts with report and bundle links.
- Deterministic --fail-on policies: 
ever, proven, supported, correlated, and ny.
- JUnit/SARIF contract tests for all four proof statuses.
- E2E validation of both formats and non-zero --fail-on proven behavior.
- GitHub Actions artifact upload for JUnit/SARIF and trusted-push SARIF Code Scanning upload.
- Documentation and pinned CI action configuration.

## Local validation

- go test ./... -count=1
- go vet ./...
- go test -race ./... -count=1
- WORLDBISECT_E2E_RACE=1 timeout --foreground 120s ./scripts/e2e.sh
- 	imeout --foreground 120s ./scripts/e2e.sh
- git diff --check

The full scripts/release-check.sh reached its WSL-native capture step but was not completed because of an existing WSL tracer hang; the isolated E2E and CI-equivalent race gates passed.

Closes #11