### PR TITLE
perf(experiment): add deterministic experiment caching

### DIFF
--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -30,6 +30,23 @@ The 1.0 engine does not claim deterministic control over:
 
 These appear as limitations or correlated evidence.
 
+## Experiment cache
+
+Experiment results are cached only after a process result and oracle outcome
+have been fully observed. The key is a SHA-256 digest of the normalized good
+and bad worlds, selected factor values, command arguments and timeout, oracle,
+cache contract, and WorldBisect tool version/commit. Capture IDs and runtime
+timestamps are deliberately excluded, so equivalent inputs reuse the same
+entry.
+
+Incomplete, corrupt, or differently keyed entries are invalidated and never
+used as evidence. The cache is bounded at 64 MiB; eviction is deterministic by
+cache-key order, and cache read/write failures do not change an analysis result.
+Reports expose cache hits and misses. A cache hit reuses only the experiment
+outcome; the current analysis receives fresh experiment identity and capture
+references, and proof still requires the normal baseline, reverse, and
+minimality checks.
+
 ## IDs and timestamps
 
 Runtime entities use collision-resistant IDs and actual timestamps. These values are excluded from semantic proof comparison and normalized in portable artifacts where determinism is required.

--- a/internal/experiment/cache.go
+++ b/internal/experiment/cache.go
@@ -1,0 +1,64 @@
+package experiment
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+
+	"github.com/ClusterPilot-System/worldbisect/internal/model"
+	"github.com/ClusterPilot-System/worldbisect/internal/version"
+)
+
+const experimentCacheContract = "worldbisect-experiment-cache-v1"
+
+type cacheManifest struct {
+	Digest  string                 `json:"digest"`
+	Entries []model.WorkspaceEntry `json:"entries"`
+}
+
+type cacheInput struct {
+	Contract        string            `json:"contract"`
+	ToolVersion     string            `json:"tool_version"`
+	ToolCommit      string            `json:"tool_commit"`
+	BaseWorld       cacheManifest     `json:"base_world"`
+	SourceWorld     cacheManifest     `json:"source_world"`
+	BaseEnvironment map[string]string `json:"base_environment"`
+	Command         []string          `json:"command"`
+	TimeoutMS       int64             `json:"timeout_ms"`
+	Oracle          model.Oracle      `json:"oracle"`
+	Factors         []model.Factor    `json:"factors"`
+	BaseIsGood      bool              `json:"base_is_good"`
+	Kind            string            `json:"kind"`
+}
+
+func experimentCacheKey(base, source *model.Capture, goodCaptureID string, command []string, selected []model.Factor, kind string) string {
+	environment := make(map[string]string, len(base.Command.Environment))
+	for key, value := range base.Command.Environment {
+		environment[key] = value
+	}
+	input := cacheInput{
+		Contract:        experimentCacheContract,
+		ToolVersion:     version.Version,
+		ToolCommit:      version.Commit,
+		BaseWorld:       manifestForCache(base.Workspace),
+		SourceWorld:     manifestForCache(source.Workspace),
+		BaseEnvironment: environment,
+		Command:         append([]string{}, command...),
+		TimeoutMS:       base.Command.TimeoutMS,
+		Oracle:          base.Oracle,
+		Factors:         append([]model.Factor{}, selected...),
+		BaseIsGood:      base.ID == goodCaptureID,
+		Kind:            kind,
+	}
+	sort.Slice(input.Factors, func(i, j int) bool { return input.Factors[i].ID < input.Factors[j].ID })
+	encoded, _ := json.Marshal(input)
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:])
+}
+
+func manifestForCache(manifest model.WorkspaceManifest) cacheManifest {
+	entries := append([]model.WorkspaceEntry{}, manifest.Entries...)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return cacheManifest{Digest: manifest.Digest, Entries: entries}
+}

--- a/internal/experiment/cache_test.go
+++ b/internal/experiment/cache_test.go
@@ -1,0 +1,32 @@
+package experiment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ClusterPilot-System/worldbisect/internal/model"
+	"github.com/ClusterPilot-System/worldbisect/internal/version"
+)
+
+func TestExperimentCacheKeyIsDeterministicAndSemantic(t *testing.T) {
+	good := &model.Capture{
+		ID: "cap-a", CreatedAt: time.Unix(1, 0), Workspace: model.WorkspaceManifest{
+			Root: "/different/root/a", Digest: "world-good", Entries: []model.WorkspaceEntry{{Path: "config.txt", Type: "file", Mode: 0o644, Digest: "digest-good"}},
+		}, Command: model.CommandSpec{Arguments: []string{"./check"}, Environment: map[string]string{"B": "2", "A": "1"}, TimeoutMS: 1000}, Oracle: model.Oracle{Kind: "exit", ExpectedExitCode: intPointer(0)},
+	}
+	bad := &model.Capture{ID: "cap-b", Workspace: model.WorkspaceManifest{Root: "/different/root/b", Digest: "world-bad", Entries: []model.WorkspaceEntry{{Path: "config.txt", Type: "file", Mode: 0o644, Digest: "digest-bad"}}}, Command: good.Command, Oracle: good.Oracle}
+	factor := model.Factor{ID: "workspace:config.txt", Type: model.FactorWorkspace, Key: "config.txt", GoodEntry: good.Workspace.Entries[0], BadEntry: bad.Workspace.Entries[0]}
+	first := experimentCacheKey(bad, good, good.ID, good.Command.Arguments, []model.Factor{factor}, "intervention")
+	second := experimentCacheKey(bad, good, good.ID, good.Command.Arguments, []model.Factor{factor}, "intervention")
+	if first != second {
+		t.Fatalf("equivalent cache keys differ: %s != %s", first, second)
+	}
+	changed := factor
+	changed.BadEntry.Digest = "different"
+	if first == experimentCacheKey(bad, good, good.ID, good.Command.Arguments, []model.Factor{changed}, "intervention") {
+		t.Fatal("semantic factor change did not invalidate cache key")
+	}
+	if version.Version == "" {
+		t.Fatal("tool version must participate in cache contract")
+	}
+}

--- a/internal/experiment/engine.go
+++ b/internal/experiment/engine.go
@@ -189,6 +189,17 @@ func (engine *Engine) runIntervention(ctx context.Context, base, source *model.C
 }
 
 func (engine *Engine) runWorld(ctx context.Context, base, source *model.Capture, goodCaptureID string, command []string, selected []model.Factor, factorIDs []string, maxOutput int64, kind string) (model.Experiment, bool, error) {
+	cacheKey := experimentCacheKey(base, source, goodCaptureID, command, selected, kind)
+	if cached, found, _ := engine.store.LoadExperimentCache(cacheKey); found {
+		cached.ID = id.New("exp")
+		cached.StartedAt = time.Now().UTC()
+		cached.FinishedAt = cached.StartedAt
+		cached.BaseCaptureID = base.ID
+		cached.SourceCaptureID = source.ID
+		cached.FactorIDs = append([]string(nil), factorIDs...)
+		cached.CacheHit = true
+		return cached, cached.OracleResult.Passed, nil
+	}
 	root, err := os.MkdirTemp("", "worldbisect-experiment-")
 	if err != nil {
 		return model.Experiment{}, false, err
@@ -251,6 +262,11 @@ func (engine *Engine) runWorld(ctx context.Context, base, source *model.Capture,
 		if result == nil {
 			return record, false, runErr
 		}
+	}
+	if result != nil && !result.TimedOut {
+		// A cache write is an optimization only. A full experiment result is
+		// still returned if the disposable cache is unavailable or full.
+		_ = engine.store.SaveExperimentCache(cacheKey, record)
 	}
 	return record, record.OracleResult.Passed, nil
 }

--- a/internal/experiment/engine_test.go
+++ b/internal/experiment/engine_test.go
@@ -53,6 +53,22 @@ func TestEngineProvesFileCause(t *testing.T) {
 	if len(analysis.CausalFactors) != 1 {
 		t.Fatalf("causal factors = %v", analysis.CausalFactors)
 	}
+	cachedAnalysis, err := New(dataStore, runner.New()).Analyze(context.Background(), Request{Good: good, Bad: bad, Command: []string{"./check.sh"}, Repetitions: 2, MaxExperiments: 64})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheHits := 0
+	for _, experiment := range cachedAnalysis.Experiments {
+		if experiment.CacheHit {
+			cacheHits++
+		}
+	}
+	if cacheHits == 0 {
+		t.Fatalf("second equivalent analysis did not reuse experiments: %+v", cachedAnalysis.Experiments)
+	}
+	if cachedAnalysis.Status != model.StatusProven {
+		t.Fatalf("cached status = %s limitations=%v", cachedAnalysis.Status, cachedAnalysis.Limitations)
+	}
 }
 
 func intPointer(value int) *int { return &value }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -146,6 +146,7 @@ type Factor struct {
 type Experiment struct {
 	ID              string        `json:"id"`
 	Kind            string        `json:"kind"`
+	CacheHit        bool          `json:"cache_hit,omitempty"`
 	StartedAt       time.Time     `json:"started_at"`
 	FinishedAt      time.Time     `json:"finished_at"`
 	BaseCaptureID   string        `json:"base_capture_id"`

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -130,6 +130,8 @@ type ReportEvidence struct {
 	BadCaptureID    string `json:"bad_capture_id"`
 	FactorCount     int    `json:"factor_count"`
 	ExperimentCount int    `json:"experiment_count"`
+	CacheHits       int    `json:"cache_hits"`
+	CacheMisses     int    `json:"cache_misses"`
 }
 
 // Build derives every supported output format from one deterministic report value.
@@ -158,6 +160,12 @@ func Build(value *model.Analysis) AnalysisReport {
 	limitations := append(make([]string, 0, len(value.Limitations)), value.Limitations...)
 	sort.Strings(boundaries)
 	sort.Strings(limitations)
+	cacheHits := 0
+	for _, experiment := range value.Experiments {
+		if experiment.CacheHit {
+			cacheHits++
+		}
+	}
 	return AnalysisReport{
 		SchemaVersion: AnalysisReportSchemaVersion,
 		Format:        "worldbisect.analysis-report.v1",
@@ -178,6 +186,8 @@ func Build(value *model.Analysis) AnalysisReport {
 			BadCaptureID:    value.BadCaptureID,
 			FactorCount:     len(value.Factors),
 			ExperimentCount: len(value.Experiments),
+			CacheHits:       cacheHits,
+			CacheMisses:     len(value.Experiments) - cacheHits,
 		},
 		Summary: value.Summary,
 	}
@@ -201,6 +211,8 @@ func JUnit(value *model.Analysis, links OutputLinks) ([]byte, error) {
 		{Name: "analysis_id", Value: report.AnalysisID},
 		{Name: "status", Value: report.Status},
 		{Name: "schema_version", Value: fmt.Sprint(report.SchemaVersion)},
+		{Name: "cache_hits", Value: fmt.Sprint(report.Evidence.CacheHits)},
+		{Name: "cache_misses", Value: fmt.Sprint(report.Evidence.CacheMisses)},
 	}
 	if links.ReportURL != "" {
 		properties = append(properties, junitProperty{Name: "report_url", Value: links.ReportURL})
@@ -247,6 +259,8 @@ func SARIF(value *model.Analysis, links OutputLinks) ([]byte, error) {
 		"forward_verified": report.Proof.ForwardVerified,
 		"reverse_verified": report.Proof.ReverseVerified,
 		"minimal_in_model": report.Proof.MinimalInModel,
+		"cache_hits":       report.Evidence.CacheHits,
+		"cache_misses":     report.Evidence.CacheMisses,
 	}
 	if links.BundleURL != "" {
 		properties["bundle_url"] = links.BundleURL
@@ -335,7 +349,7 @@ func Markdown(value *model.Analysis) string {
 		}
 		fmt.Fprintln(&builder)
 	}
-	fmt.Fprintf(&builder, "\n<sub>Analysis `%s`; experiments: %d; factors: %d.</sub>\n", report.AnalysisID, report.Evidence.ExperimentCount, report.Evidence.FactorCount)
+	fmt.Fprintf(&builder, "\n<sub>Analysis `%s`; experiments: %d; factors: %d; cache hits: %d; cache misses: %d.</sub>\n", report.AnalysisID, report.Evidence.ExperimentCount, report.Evidence.FactorCount, report.Evidence.CacheHits, report.Evidence.CacheMisses)
 	return builder.String()
 }
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -15,7 +15,7 @@ func provenAnalysis() *model.Analysis {
 	return &model.Analysis{
 		ID: "ana_test", GoodCaptureID: "cap_good", BadCaptureID: "cap_bad",
 		Status: model.StatusProven, ForwardVerified: true, ReverseVerified: true, MinimalInModel: true,
-		CausalFactors: []string{"workspace:config.txt"}, Experiments: make([]model.Experiment, 9),
+		CausalFactors: []string{"workspace:config.txt"}, Experiments: []model.Experiment{{CacheHit: true}, {}, {}},
 		Factors:            []model.Factor{{ID: "workspace:config.txt", Type: model.FactorWorkspace, Key: "config.txt", GoodEntry: model.WorkspaceEntry{Type: "file"}}},
 		EvidenceBoundaries: []string{"host scheduling was not controlled"},
 		Limitations:        []string{"proof applies only to the supported intervention model"},
@@ -42,6 +42,10 @@ func TestAnalysisReportJSONHasStableContract(t *testing.T) {
 	if strings.Contains(string(encoded), "good_value") || strings.Contains(string(encoded), "bad_value") {
 		t.Fatalf("report exposed internal factor values: %s", encoded)
 	}
+	evidence, ok := value["evidence"].(map[string]any)
+	if !ok || evidence["cache_hits"] != float64(1) || evidence["cache_misses"] != float64(2) {
+		t.Fatalf("cache evidence = %+v", value["evidence"])
+	}
 }
 
 func TestAnalysisReportMarkdownIsGitHubReady(t *testing.T) {
@@ -49,7 +53,7 @@ func TestAnalysisReportMarkdownIsGitHubReady(t *testing.T) {
 	for _, expected := range []string{
 		"# WorldBisect diagnosis", "**Status:** `PROVEN`", "## Proof",
 		"## Confirmed or suspected cause", "workspace file \"config.txt\"",
-		"## Next steps", "## Evidence boundaries", "Analysis `ana_test`",
+		"## Next steps", "## Evidence boundaries", "cache hits: 1; cache misses: 2", "Analysis `ana_test`",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("markdown does not contain %q:\n%s", expected, output)

--- a/internal/report/testdata/status_correlated.md
+++ b/internal/report/testdata/status_correlated.md
@@ -18,4 +18,4 @@ No cause was confirmed within the supported test model.
 2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
 3. Run the comparison again after removing uncontrolled differences where possible.
 
-<sub>Analysis `ana_correlated`; experiments: 0; factors: 0.</sub>
+<sub>Analysis `ana_correlated`; experiments: 0; factors: 0; cache hits: 0; cache misses: 0.</sub>

--- a/internal/report/testdata/status_proven.md
+++ b/internal/report/testdata/status_proven.md
@@ -18,4 +18,4 @@ No cause was confirmed within the supported test model.
 2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
 3. Run the comparison again after removing uncontrolled differences where possible.
 
-<sub>Analysis `ana_proven`; experiments: 0; factors: 0.</sub>
+<sub>Analysis `ana_proven`; experiments: 0; factors: 0; cache hits: 0; cache misses: 0.</sub>

--- a/internal/report/testdata/status_supported.md
+++ b/internal/report/testdata/status_supported.md
@@ -18,4 +18,4 @@ No cause was confirmed within the supported test model.
 2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
 3. Run the comparison again after removing uncontrolled differences where possible.
 
-<sub>Analysis `ana_supported`; experiments: 0; factors: 0.</sub>
+<sub>Analysis `ana_supported`; experiments: 0; factors: 0; cache hits: 0; cache misses: 0.</sub>

--- a/internal/report/testdata/status_unproven.md
+++ b/internal/report/testdata/status_unproven.md
@@ -18,4 +18,4 @@ No cause was confirmed within the supported test model.
 2. Capture a new good run and bad run with the same command, oracle, workspace scope, and stable inputs.
 3. Run the comparison again after removing uncontrolled differences where possible.
 
-<sub>Analysis `ana_unproven`; experiments: 0; factors: 0.</sub>
+<sub>Analysis `ana_unproven`; experiments: 0; factors: 0; cache hits: 0; cache misses: 0.</sub>

--- a/internal/store/experiment_cache.go
+++ b/internal/store/experiment_cache.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/ClusterPilot-System/worldbisect/internal/model"
+)
+
+// MaxExperimentCacheBytes bounds persisted experiment evidence. Cache data is
+// disposable; exceeding the limit must never make an analysis fail.
+const MaxExperimentCacheBytes int64 = 64 << 20
+
+type experimentCacheEntry struct {
+	Key        string           `json:"key"`
+	Complete   bool             `json:"complete"`
+	Experiment model.Experiment `json:"experiment"`
+}
+
+// LoadExperimentCache returns only a complete entry for the exact key. Invalid
+// or incomplete entries are discarded as stale cache state, never interpreted
+// as experiment evidence.
+func (store *Store) LoadExperimentCache(key string) (model.Experiment, bool, error) {
+	if !validDigest(key) {
+		return model.Experiment{}, false, errors.New("invalid experiment cache key")
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	path := filepath.Join(store.root, "experiment-cache", key+".json")
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return model.Experiment{}, false, nil
+	}
+	if err != nil {
+		return model.Experiment{}, false, err
+	}
+	var entry experimentCacheEntry
+	if err := json.Unmarshal(content, &entry); err != nil || entry.Key != key || !entry.Complete {
+		_ = os.Remove(path)
+		return model.Experiment{}, false, nil
+	}
+	return entry.Experiment, true, nil
+}
+
+// SaveExperimentCache atomically persists one complete observed experiment and
+// prunes deterministically until the bounded cache fits. Cache failures are
+// intentionally returned to the caller so analysis can ignore them safely.
+func (store *Store) SaveExperimentCache(key string, experiment model.Experiment) error {
+	if !validDigest(key) {
+		return errors.New("invalid experiment cache key")
+	}
+	entry := experimentCacheEntry{Key: key, Complete: true, Experiment: experiment}
+	content, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	if int64(len(content)) > MaxExperimentCacheBytes {
+		return errors.New("experiment cache entry exceeds size limit")
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	path := filepath.Join(store.root, "experiment-cache", key+".json")
+	if err := writeFileAtomic(path, content, 0o640); err != nil {
+		return err
+	}
+	return store.pruneExperimentCacheLocked(key)
+}
+
+func (store *Store) pruneExperimentCacheLocked(preserve string) error {
+	paths, err := filepath.Glob(filepath.Join(store.root, "experiment-cache", "*.json"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(paths)
+	var total int64
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+	}
+	for _, path := range paths {
+		if total <= MaxExperimentCacheBytes || filepath.Base(path) == preserve+".json" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+		total -= info.Size()
+	}
+	if total > MaxExperimentCacheBytes {
+		return os.Remove(filepath.Join(store.root, "experiment-cache", preserve+".json"))
+	}
+	return nil
+}

--- a/internal/store/experiment_cache_test.go
+++ b/internal/store/experiment_cache_test.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ClusterPilot-System/worldbisect/internal/model"
+)
+
+func TestExperimentCacheRoundTripAndInvalidation(t *testing.T) {
+	dataStore, err := Open(filepath.Join(t.TempDir(), "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := strings.Repeat("a", 64)
+	want := model.Experiment{ID: "exp-1", Kind: "baseline", OracleResult: model.OracleResult{Passed: true}}
+	if err := dataStore.SaveExperimentCache(key, want); err != nil {
+		t.Fatal(err)
+	}
+	got, found, err := dataStore.LoadExperimentCache(key)
+	if err != nil || !found || got.ID != want.ID || !got.OracleResult.Passed {
+		t.Fatalf("cache result=%+v found=%t err=%v", got, found, err)
+	}
+
+	path := filepath.Join(dataStore.Root(), "experiment-cache", key+".json")
+	if err := os.WriteFile(path, []byte(`{"key":"`+key+`","complete":false}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := dataStore.LoadExperimentCache(key); err != nil || found {
+		t.Fatalf("incomplete cache reused: found=%t err=%v", found, err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("incomplete cache was not invalidated: %v", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -57,7 +57,7 @@ func (store *Store) Root() string { return store.root }
 func (store *Store) initialize() error {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
-	for _, directory := range []string{"captures", "analyses", "jobs", "idempotency", "blobs/sha256", "audit", "keys", "traces"} {
+	for _, directory := range []string{"captures", "analyses", "jobs", "idempotency", "experiment-cache", "blobs/sha256", "audit", "keys", "traces"} {
 		if err := os.MkdirAll(filepath.Join(store.root, directory), 0o750); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- add a persisted, bounded experiment-result cache keyed by normalized semantic inputs
- include worlds, selected factors, command/oracle, cache contract, and tool version/commit in the key
- reuse only complete exact-key results; invalidate corrupt/incomplete entries
- keep cache failures and eviction fail-open for analysis correctness
- expose cache hits and misses in JSON, Markdown, JUnit, and SARIF reports
- add deterministic-key, invalidation, round-trip, and repeated-analysis tests

Closes #13

## Validation
- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `WORLDBISECT_E2E_RACE=1 timeout --foreground 120s ./scripts/e2e.sh`
- focused Store/Experiment/Report tests
- `git diff --check`

The second equivalent analysis in the engine test reuses persisted experiments and remains `PROVEN`; cache hits do not bypass baseline, reverse, or minimality checks.