### PR TITLE
feat(factors): harden workspace interventions

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -65,6 +65,13 @@ worldbisect compare \
 
 WorldBisect imports bundles when a path is supplied, compares the sessions, reruns the baselines, tests candidate groups, minimizes a supported factor set, reverses the intervention direction, and records all experiments.
 
+Workspace factors are limited to regular file content/presence, permission
+bits, directories, and relative symlinks whose targets remain inside the
+workspace. Absolute targets, traversal targets, unsupported filesystem objects,
+and symlink escapes are reported as evidence boundaries and are never applied.
+Experiments run in fresh temporary directories; the original workspaces are
+not modified.
+
 ## Result states
 
 The default text report is intended for normal operators. It presents the

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -402,7 +402,7 @@ func workspaceKind(factor model.Factor) string {
 		entry = factor.BadEntry
 	}
 	switch entry.Type {
-	case "directory":
+	case "dir", "directory":
 		return "directory"
 	case "symlink":
 		return "symbolic link"

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -93,6 +93,13 @@ func TestEveryStatusHasUnambiguousContractAndMarkdown(t *testing.T) {
 	}
 }
 
+func TestDirectoryFactorUsesPlainLanguage(t *testing.T) {
+	value := &model.Analysis{ID: "ana_directory", Status: model.StatusSupported, CausalFactors: []string{"workspace:config"}, Factors: []model.Factor{{ID: "workspace:config", Type: model.FactorWorkspace, Key: "config", GoodEntry: model.WorkspaceEntry{Type: "dir"}}}}
+	if !strings.Contains(Markdown(value), `workspace directory "config"`) {
+		t.Fatalf("directory factor was not described plainly: %s", Markdown(value))
+	}
+}
+
 func TestAnalysisReportIsDeterministic(t *testing.T) {
 	firstOutput, err := JSON(provenAnalysis())
 	if err != nil {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -101,6 +101,11 @@ func Scan(root string, dataStore *store.Store, maxFiles int, maxBytes int64) (mo
 				return err
 			}
 			item.Digest = digestString(item.LinkTarget)
+			if err := validateLinkTarget(relative, item.LinkTarget); err != nil {
+				// Preserve the observation for comparison, but make it an
+				// explicit boundary instead of an intervenable factor.
+				item.Type = "unsupported"
+			}
 		default:
 			item.Type = "unsupported"
 		}
@@ -148,6 +153,11 @@ func Apply(root, relative string, entry model.WorkspaceEntry, present bool, data
 	if err != nil {
 		return err
 	}
+	if present && entry.Type == "symlink" {
+		if err := validateLinkTarget(relative, entry.LinkTarget); err != nil {
+			return err
+		}
+	}
 	if err := removeExisting(path); err != nil {
 		return err
 	}
@@ -160,7 +170,10 @@ func Apply(root, relative string, entry model.WorkspaceEntry, present bool, data
 	mode := os.FileMode(entry.Mode)
 	switch entry.Type {
 	case "dir":
-		return os.MkdirAll(path, mode.Perm())
+		if err := os.MkdirAll(path, mode.Perm()); err != nil {
+			return err
+		}
+		return os.Chmod(path, mode.Perm())
 	case "symlink":
 		if entry.LinkTarget == "" {
 			return errors.New("symlink target missing")
@@ -171,7 +184,10 @@ func Apply(root, relative string, entry model.WorkspaceEntry, present bool, data
 		if err != nil {
 			return err
 		}
-		return os.WriteFile(path, content, mode.Perm())
+		if err := os.WriteFile(path, content, mode.Perm()); err != nil {
+			return err
+		}
+		return os.Chmod(path, mode.Perm())
 	default:
 		return fmt.Errorf("unsupported workspace entry type %q", entry.Type)
 	}
@@ -195,6 +211,18 @@ func unsafeRelative(relative string) bool {
 	}
 	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(relative)))
 	return clean != relative || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../")
+}
+
+func validateLinkTarget(relative, target string) error {
+	if target == "" || filepath.IsAbs(target) || strings.Contains(target, "\\") {
+		return errors.New("symlink target must be a non-empty relative Unix path")
+	}
+	linkPath := filepath.ToSlash(filepath.Join(filepath.Dir(relative), target))
+	clean := filepath.ToSlash(filepath.Clean(linkPath))
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return errors.New("symlink target escapes workspace")
+	}
+	return nil
 }
 
 func removeExisting(path string) error {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -48,3 +48,54 @@ func TestApplyRejectsTraversal(t *testing.T) {
 		t.Fatal("expected traversal rejection")
 	}
 }
+
+func TestApplyRejectsSymlinkEscape(t *testing.T) {
+	dataStore, _ := store.Open(filepath.Join(t.TempDir(), "store"))
+	root := t.TempDir()
+	for _, target := range []string{"/etc/passwd", "../../outside", `..\outside`} {
+		if err := Apply(root, "nested/link", model.WorkspaceEntry{Type: "symlink", Mode: 0o777, LinkTarget: target}, true, dataStore); err == nil {
+			t.Fatalf("symlink escape accepted: %q", target)
+		}
+	}
+}
+
+func TestScanMarksEscapingSymlinkUnsupported(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink("../outside", filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	dataStore, err := store.Open(filepath.Join(t.TempDir(), "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := Scan(root, dataStore, 100, 1<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Entries) != 1 || manifest.Entries[0].Type != "unsupported" {
+		t.Fatalf("escaping symlink was not bounded: %+v", manifest.Entries)
+	}
+	if err := Materialize(filepath.Join(t.TempDir(), "destination"), manifest, dataStore); err == nil {
+		t.Fatal("unsupported escaping symlink was materialized")
+	}
+}
+
+func TestApplyPreservesFileAndDirectoryModes(t *testing.T) {
+	dataStore, _ := store.Open(filepath.Join(t.TempDir(), "store"))
+	digest, err := dataStore.PutBlob([]byte("content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := Apply(root, "private", model.WorkspaceEntry{Type: "dir", Mode: 0o750}, true, dataStore); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(root, "private/file", model.WorkspaceEntry{Type: "file", Mode: 0o640, BlobDigest: digest}, true, dataStore); err != nil {
+		t.Fatal(err)
+	}
+	directoryInfo, _ := os.Stat(filepath.Join(root, "private"))
+	fileInfo, _ := os.Stat(filepath.Join(root, "private", "file"))
+	if directoryInfo.Mode().Perm() != 0o750 || fileInfo.Mode().Perm() != 0o640 {
+		t.Fatalf("modes not preserved: directory=%o file=%o", directoryInfo.Mode().Perm(), fileInfo.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Summary
- bound workspace symlink targets to relative paths inside the workspace
- preserve unsafe symlink observations as explicit unsupported boundaries
- reject traversal and unsafe symlink materialization before mutating the temporary world
- apply file and directory permission bits after materialization
- describe directory factors correctly in operator reports
- add security regression tests for traversal, symlink escapes, modes, and unsupported entries

Closes #14

## Validation
- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `WORLDBISECT_E2E_RACE=1 timeout --foreground 120s ./scripts/e2e.sh`
- focused workspace/report/experiment tests
- `git diff --check`

The original workspace remains untouched; interventions continue to run only in fresh temporary materializations.