### PR TITLE
feat: add offline-verifiable causal certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ captures, signed certificate, Markdown report, JSON report, and checksummed
 manifest. Raw command output, workspace content blobs, and secret-looking
 values are intentionally excluded.
 
+`verify` performs an offline signature check and returns a machine-readable
+`valid`, `trust`, and `next_action` result. Use `--public-key` when the signing
+key must also match an independently retained trust root. Current v2
+certificates carry hashes for the captures, experiments, and factor set rather
+than copying raw evidence; changing any signed claim or digest fails closed.
+
 For CI integrations, `compare` and `explain` also support `--format junit` and
 `--format sarif`. JUnit marks `PROVEN` and `SUPPORTED` as failures and the
 other statuses as explicit skips. SARIF emits an `error` for `PROVEN`, a

--- a/cmd/worldbisect/main.go
+++ b/cmd/worldbisect/main.go
@@ -410,7 +410,13 @@ func runVerify(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, result)
+	if err := writeJSON(stdout, result); err != nil {
+		return err
+	}
+	if !result.Valid {
+		return errors.New("certificate verification failed")
+	}
+	return nil
 }
 
 func runAudit(args []string, stdout io.Writer) error {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -192,9 +192,21 @@ fails the check without hiding the report.
 
 ```bash
 worldbisect verify result.wbc
+# To require a separately retained trust root:
+worldbisect verify --public-key causal_ed25519_public.pem result.wbc
 ```
 
-Optionally supply an independently trusted public key.
+The command prints a JSON result and exits non-zero when verification fails. A
+v2 certificate contains the proof status, model name, capture identifiers, and
+SHA-256 digests of the good capture, bad capture, experiment set, and factor
+set. It does not contain raw command output, workspace files, factor values, or
+experiment details. The `trust` field distinguishes the embedded signing key
+from a key matched with `--public-key`; an embedded key proves integrity, but
+not that the key belongs to a person or organization. The `next_action` field
+states what to review after a valid check. A changed claim, signature, or
+evidence digest causes verification to fail. Older v1 certificates remain
+readable, but report that evidence digests are unavailable and should be
+reviewed against their original evidence bundle.
 
 ## Audit
 

--- a/internal/artifact/certificate.go
+++ b/internal/artifact/certificate.go
@@ -12,25 +12,70 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/ClusterPilot-System/worldbisect/internal/model"
 	"github.com/ClusterPilot-System/worldbisect/internal/store"
 )
 
+const (
+	certificateV1 = "worldbisect.causal-certificate.v1"
+	certificateV2 = "worldbisect.causal-certificate.v2"
+)
+
+// CertificateEvidence contains only public digests. It deliberately excludes
+// capture contents, command output, factor values, and other secret-bearing
+// evidence from the offline certificate.
+type CertificateEvidence struct {
+	GoodCaptureSHA256 string `json:"good_capture_sha256"`
+	BadCaptureSHA256  string `json:"bad_capture_sha256"`
+	ExperimentsSHA256 string `json:"experiments_sha256"`
+	FactorSetSHA256   string `json:"factor_set_sha256"`
+}
+
+type CertificateClaims struct {
+	Model              string              `json:"model"`
+	AnalysisID         string              `json:"analysis_id"`
+	Status             model.ProofStatus   `json:"status"`
+	GoodCaptureID      string              `json:"good_capture_id"`
+	BadCaptureID       string              `json:"bad_capture_id"`
+	CausalFactors      []string            `json:"causal_factors,omitempty"`
+	ForwardVerified    bool                `json:"forward_verified"`
+	ReverseVerified    bool                `json:"reverse_verified"`
+	MinimalInModel     bool                `json:"minimal_in_model"`
+	EvidenceBoundaries []string            `json:"evidence_boundaries,omitempty"`
+	Limitations        []string            `json:"limitations,omitempty"`
+	Evidence           CertificateEvidence `json:"evidence"`
+}
+
+// Certificate keeps v1 Payload as raw JSON so old certificates remain
+// readable while v2 uses secret-safe Claims.
 type Certificate struct {
-	Format      string         `json:"format"`
-	Payload     model.Analysis `json:"payload"`
-	PublicKey   string         `json:"public_key"`
-	Signature   string         `json:"signature"`
-	GeneratedAt time.Time      `json:"generated_at"`
+	Format      string             `json:"format"`
+	Payload     json.RawMessage    `json:"payload,omitempty"`
+	Claims      *CertificateClaims `json:"claims,omitempty"`
+	PublicKey   string             `json:"public_key"`
+	Signature   string             `json:"signature"`
+	GeneratedAt time.Time          `json:"generated_at"`
+}
+
+type signedV2Value struct {
+	Format      string            `json:"format"`
+	Claims      CertificateClaims `json:"claims"`
+	GeneratedAt time.Time         `json:"generated_at"`
 }
 
 type VerificationResult struct {
-	Valid      bool   `json:"valid"`
-	AnalysisID string `json:"analysis_id,omitempty"`
-	Status     string `json:"status,omitempty"`
-	Error      string `json:"error,omitempty"`
+	Valid      bool                 `json:"valid"`
+	Format     string               `json:"format,omitempty"`
+	AnalysisID string               `json:"analysis_id,omitempty"`
+	Status     string               `json:"status,omitempty"`
+	Trust      string               `json:"trust,omitempty"`
+	Model      string               `json:"model,omitempty"`
+	Evidence   *CertificateEvidence `json:"evidence,omitempty"`
+	NextAction string               `json:"next_action,omitempty"`
+	Error      string               `json:"error,omitempty"`
 }
 
 func WriteCertificate(dataStore *store.Store, analysisID, output string) error {
@@ -46,27 +91,79 @@ func WriteCertificate(dataStore *store.Store, analysisID, output string) error {
 	if err != nil {
 		return err
 	}
-	encoded = append(encoded, '\n')
-	return atomicWriteFile(output, encoded, 0o644)
+	return atomicWriteFile(output, append(encoded, '\n'), 0o644)
 }
 
 func certificateForAnalysis(dataStore *store.Store, analysis *model.Analysis) (Certificate, error) {
+	good, err := dataStore.LoadCapture(analysis.GoodCaptureID)
+	if err != nil {
+		return Certificate{}, err
+	}
+	bad, err := dataStore.LoadCapture(analysis.BadCaptureID)
+	if err != nil {
+		return Certificate{}, err
+	}
+	return certificateForAnalysisWithEvidence(dataStore, analysis, good, bad)
+}
+
+func certificateForAnalysisWithEvidence(dataStore *store.Store, analysis *model.Analysis, good, bad *model.Capture) (Certificate, error) {
 	privateKey, publicKey, err := loadOrCreateSigningKey(dataStore.Root())
 	if err != nil {
 		return Certificate{}, err
 	}
-	payload, err := json.Marshal(analysis)
+	claims := claimsForAnalysis(analysis, good, bad)
+	certificate := Certificate{Format: certificateV2, Claims: &claims, PublicKey: base64.RawStdEncoding.EncodeToString(publicKey), GeneratedAt: analysis.CreatedAt}
+	payload, err := signedV2Bytes(certificate)
 	if err != nil {
 		return Certificate{}, err
 	}
-	signature := ed25519.Sign(privateKey, payload)
-	return Certificate{
-		Format:      "worldbisect.causal-certificate.v1",
-		Payload:     *analysis,
-		PublicKey:   base64.RawStdEncoding.EncodeToString(publicKey),
-		Signature:   base64.RawStdEncoding.EncodeToString(signature),
-		GeneratedAt: analysis.CreatedAt,
-	}, nil
+	certificate.Signature = base64.RawStdEncoding.EncodeToString(ed25519.Sign(privateKey, payload))
+	return certificate, nil
+}
+
+func claimsForAnalysis(analysis *model.Analysis, good, bad *model.Capture) CertificateClaims {
+	causalFactors := append([]string(nil), analysis.CausalFactors...)
+	sort.Strings(causalFactors)
+	evidenceBoundaries := append([]string(nil), analysis.EvidenceBoundaries...)
+	sort.Strings(evidenceBoundaries)
+	limitations := append([]string(nil), analysis.Limitations...)
+	sort.Strings(limitations)
+	factors := append([]model.Factor(nil), analysis.Factors...)
+	sort.Slice(factors, func(i, j int) bool { return factors[i].ID < factors[j].ID })
+	return CertificateClaims{
+		Model:              "worldbisect.causal-model.v1",
+		AnalysisID:         analysis.ID,
+		Status:             analysis.Status,
+		GoodCaptureID:      analysis.GoodCaptureID,
+		BadCaptureID:       analysis.BadCaptureID,
+		CausalFactors:      causalFactors,
+		ForwardVerified:    analysis.ForwardVerified,
+		ReverseVerified:    analysis.ReverseVerified,
+		MinimalInModel:     analysis.MinimalInModel,
+		EvidenceBoundaries: evidenceBoundaries,
+		Limitations:        limitations,
+		Evidence: CertificateEvidence{
+			GoodCaptureSHA256: hashCertificateValue(good),
+			BadCaptureSHA256:  hashCertificateValue(bad),
+			ExperimentsSHA256: hashCertificateValue(analysis.Experiments),
+			FactorSetSHA256: hashCertificateValue(struct {
+				Factors       []model.Factor `json:"factors"`
+				CausalFactors []string       `json:"causal_factors"`
+			}{Factors: factors, CausalFactors: causalFactors}),
+		},
+	}
+}
+
+func hashCertificateValue(value any) string {
+	encoded, _ := canonicalJSON(value)
+	return digest(encoded)
+}
+
+func signedV2Bytes(certificate Certificate) ([]byte, error) {
+	if certificate.Claims == nil {
+		return nil, errors.New("certificate claims are required")
+	}
+	return canonicalJSON(signedV2Value{Format: certificate.Format, Claims: *certificate.Claims, GeneratedAt: certificate.GeneratedAt})
 }
 
 func VerifyCertificate(path, publicKeyPath string) (VerificationResult, error) {
@@ -80,36 +177,123 @@ func VerifyCertificate(path, publicKeyPath string) (VerificationResult, error) {
 	if err := decoder.Decode(&certificate); err != nil {
 		return VerificationResult{}, err
 	}
-	if certificate.Format != "worldbisect.causal-certificate.v1" {
-		return VerificationResult{Valid: false, Error: "unsupported certificate format"}, nil
-	}
 	publicKeyBytes, err := base64.RawStdEncoding.DecodeString(certificate.PublicKey)
-	if err != nil {
-		return VerificationResult{Valid: false, Error: "invalid embedded public key"}, nil
+	if err != nil || len(publicKeyBytes) != ed25519.PublicKeySize {
+		return VerificationResult{Valid: false, Format: certificate.Format, Trust: "untrusted", Error: "invalid embedded public key", NextAction: "obtain a complete certificate and inspect its trust key"}, nil
 	}
+	trust := "embedded key not independently trusted"
 	if publicKeyPath != "" {
 		trusted, err := readPublicKey(publicKeyPath)
 		if err != nil {
 			return VerificationResult{}, err
 		}
 		if !bytes.Equal(trusted, publicKeyBytes) {
-			return VerificationResult{Valid: false, Error: "certificate public key is not trusted key"}, nil
+			return VerificationResult{Valid: false, Format: certificate.Format, Trust: "untrusted", Error: "certificate public key is not trusted key", NextAction: "use the public key belonging to the signing trust root"}, nil
 		}
+		trust = "independently trusted key matched"
 	}
 	signature, err := base64.RawStdEncoding.DecodeString(certificate.Signature)
-	if err != nil {
-		return VerificationResult{Valid: false, Error: "invalid signature encoding"}, nil
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return VerificationResult{Valid: false, Format: certificate.Format, Trust: trust, Error: "invalid signature encoding", NextAction: "obtain a complete certificate"}, nil
 	}
-	payload, err := json.Marshal(certificate.Payload)
+	result := VerificationResult{Valid: false, Format: certificate.Format, Trust: trust}
+	var signed []byte
+	switch certificate.Format {
+	case certificateV1:
+		var analysis model.Analysis
+		if err := json.Unmarshal(certificate.Payload, &analysis); err != nil {
+			return VerificationResult{}, err
+		}
+		signed, err = json.Marshal(analysis)
+		result.AnalysisID = analysis.ID
+		result.Status = string(analysis.Status)
+		result.Model = "legacy embedded analysis; evidence hashes unavailable"
+		result.NextAction = "treat this as a legacy certificate and independently review its evidence"
+	case certificateV2:
+		if certificate.Claims == nil || certificate.Claims.Model != "worldbisect.causal-model.v1" {
+			return VerificationResult{Valid: false, Format: certificate.Format, Trust: trust, Error: "unsupported certificate model", NextAction: "use a certificate with a supported causal model"}, nil
+		}
+		signed, err = signedV2Bytes(certificate)
+		result.AnalysisID = certificate.Claims.AnalysisID
+		result.Status = string(certificate.Claims.Status)
+		result.Model = certificate.Claims.Model
+		result.Evidence = &certificate.Claims.Evidence
+		result.NextAction = "compare the evidence hashes with the retained captures and review the model boundaries"
+	default:
+		return VerificationResult{Valid: false, Format: certificate.Format, Trust: trust, Error: "unsupported certificate format", NextAction: "use a supported certificate version"}, nil
+	}
 	if err != nil {
 		return VerificationResult{}, err
 	}
-	valid := ed25519.Verify(ed25519.PublicKey(publicKeyBytes), payload, signature)
-	result := VerificationResult{Valid: valid, AnalysisID: certificate.Payload.ID, Status: string(certificate.Payload.Status)}
-	if !valid {
-		result.Error = "signature verification failed"
+	result.Valid = ed25519.Verify(ed25519.PublicKey(publicKeyBytes), signed, signature)
+	if !result.Valid {
+		result.Error = "signature verification failed; certificate evidence or metadata was tampered with"
+		result.NextAction = "discard this certificate and obtain a fresh signed evidence bundle"
 	}
 	return result, nil
+}
+
+func verifyCertificateValue(certificate Certificate, analysis *model.Analysis, good, bad *model.Capture) VerificationResult {
+	result, err := verifyCertificateForAnalysis(certificate, analysis, good, bad)
+	if err != nil {
+		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: err.Error(), NextAction: "discard the certificate and obtain a fresh diagnostic bundle"}
+	}
+	return result
+}
+
+func verifyCertificateForAnalysis(certificate Certificate, analysis *model.Analysis, good, bad *model.Capture) (VerificationResult, error) {
+	if certificate.Format == certificateV1 {
+		var payload model.Analysis
+		if err := json.Unmarshal(certificate.Payload, &payload); err != nil {
+			return VerificationResult{}, err
+		}
+		expected, err := json.Marshal(payload)
+		if err != nil || !bytes.Equal(expected, mustJSON(analysis)) {
+			return VerificationResult{}, errors.New("certificate payload does not match analysis")
+		}
+		return verifyCertificateSignature(certificate, expected, string(payload.Status), "legacy embedded analysis; evidence hashes unavailable"), nil
+	}
+	if certificate.Format != certificateV2 || certificate.Claims == nil {
+		return VerificationResult{}, errors.New("unsupported certificate format or missing claims")
+	}
+	expected := claimsForAnalysis(analysis, good, bad)
+	if !bytes.Equal(mustJSON(expected), mustJSON(*certificate.Claims)) {
+		return VerificationResult{}, errors.New("certificate claims or evidence hashes do not match analysis")
+	}
+	signed, err := signedV2Bytes(certificate)
+	if err != nil {
+		return VerificationResult{}, err
+	}
+	return verifyCertificateSignature(certificate, signed, string(certificate.Claims.Status), certificate.Claims.Model), nil
+}
+
+func verifyCertificateSignature(certificate Certificate, signed []byte, status, modelName string) VerificationResult {
+	key, keyErr := base64.RawStdEncoding.DecodeString(certificate.PublicKey)
+	signature, sigErr := base64.RawStdEncoding.DecodeString(certificate.Signature)
+	valid := keyErr == nil && sigErr == nil && len(key) == ed25519.PublicKeySize && len(signature) == ed25519.SignatureSize && ed25519.Verify(ed25519.PublicKey(key), signed, signature)
+	result := VerificationResult{Valid: valid, Format: certificate.Format, AnalysisID: certificate.ClaimsID(), Status: status, Trust: "embedded key not independently trusted", Model: modelName, NextAction: "compare the evidence hashes with retained evidence and review model boundaries"}
+	if certificate.Claims != nil {
+		result.Evidence = &certificate.Claims.Evidence
+	}
+	if !valid {
+		result.Error = "signature verification failed"
+		result.NextAction = "discard this certificate and obtain a fresh signed evidence bundle"
+	}
+	return result
+}
+
+func (certificate Certificate) ClaimsID() string {
+	if certificate.Claims != nil {
+		return certificate.Claims.AnalysisID
+	}
+	var analysis model.Analysis
+	_ = json.Unmarshal(certificate.Payload, &analysis)
+	return analysis.ID
+}
+
+func mustJSON(value any) []byte {
+	encoded, _ := json.Marshal(value)
+	return encoded
 }
 
 func loadOrCreateSigningKey(root string) (ed25519.PrivateKey, ed25519.PublicKey, error) {

--- a/internal/artifact/certificate_test.go
+++ b/internal/artifact/certificate_test.go
@@ -1,8 +1,13 @@
 package artifact
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,12 +15,26 @@ import (
 	"github.com/ClusterPilot-System/worldbisect/internal/store"
 )
 
-func TestCertificateRoundTrip(t *testing.T) {
+func TestCertificateRoundTripAndSecretSafeClaims(t *testing.T) {
 	dataStore, err := store.Open(filepath.Join(t.TempDir(), "store"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	analysis := &model.Analysis{SchemaVersion: 3, ID: "analysis-1", CreatedAt: time.Now().UTC(), Status: model.StatusProven}
+	createdAt := time.Date(2026, 8, 21, 10, 0, 0, 0, time.UTC)
+	good := &model.Capture{SchemaVersion: 3, ID: "good-1", CreatedAt: createdAt, Label: "good"}
+	bad := &model.Capture{SchemaVersion: 3, ID: "bad-1", CreatedAt: createdAt, Label: "bad"}
+	if err := dataStore.SaveCapture(good); err != nil {
+		t.Fatal(err)
+	}
+	if err := dataStore.SaveCapture(bad); err != nil {
+		t.Fatal(err)
+	}
+	analysis := &model.Analysis{
+		SchemaVersion: 3, ID: "analysis-1", CreatedAt: createdAt,
+		GoodCaptureID: good.ID, BadCaptureID: bad.ID, Status: model.StatusProven,
+		Summary: "supersecret summary", Factors: []model.Factor{{ID: "factor-1", GoodValue: "supersecret"}},
+		Experiments: []model.Experiment{{ID: "experiment-1", Error: "supersecret experiment output"}},
+	}
 	if err := dataStore.SaveAnalysis(analysis); err != nil {
 		t.Fatal(err)
 	}
@@ -27,18 +46,63 @@ func TestCertificateRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !result.Valid || result.AnalysisID != analysis.ID {
+	if !result.Valid || result.Format != certificateV2 || result.AnalysisID != analysis.ID || result.Evidence == nil {
 		t.Fatalf("verification failed: %+v", result)
 	}
 	content, err := os.ReadFile(certificate)
 	if err != nil {
 		t.Fatal(err)
 	}
-	content[len(content)/2] ^= 1
-	if err := os.WriteFile(certificate, content, 0o644); err != nil {
+	if strings.Contains(string(content), "supersecret") || strings.Contains(string(content), "experiment-1") {
+		t.Fatal("certificate contains raw or secret-bearing evidence")
+	}
+
+	var tampered Certificate
+	if err := json.Unmarshal(content, &tampered); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := VerifyCertificate(certificate, ""); err == nil {
-		t.Fatal("expected malformed or invalid certificate")
+	tampered.Claims.Status = model.StatusUnproven
+	tamperedBytes, err := json.Marshal(tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certificate, tamperedBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tamperedResult, err := VerifyCertificate(certificate, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tamperedResult.Valid || tamperedResult.Error == "" {
+		t.Fatalf("tampered certificate unexpectedly verified: %+v", tamperedResult)
+	}
+}
+
+func TestLegacyCertificateRemainsReadable(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := model.Analysis{SchemaVersion: 3, ID: "legacy-1", Status: model.StatusProven}
+	payload, err := json.Marshal(analysis)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate := Certificate{
+		Format: certificateV1, Payload: payload,
+		PublicKey: base64.RawStdEncoding.EncodeToString(publicKey),
+		Signature: base64.RawStdEncoding.EncodeToString(ed25519.Sign(privateKey, payload)),
+	}
+	path := filepath.Join(t.TempDir(), "legacy.wbc")
+	encoded, err := json.Marshal(certificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := VerifyCertificate(path, "")
+	if err != nil || !result.Valid || result.AnalysisID != analysis.ID {
+		t.Fatalf("legacy certificate verification failed: %+v %v", result, err)
 	}
 }

--- a/internal/artifact/diagnostic.go
+++ b/internal/artifact/diagnostic.go
@@ -4,8 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"crypto/ed25519"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,7 +63,7 @@ func ExportDiagnostic(dataStore *store.Store, analysisID, output string) error {
 	redactedGood := redactCapture(good)
 	redactedBad := redactCapture(bad)
 
-	certificate, err := certificateForAnalysis(dataStore, redactedAnalysis)
+	certificate, err := certificateForAnalysisWithEvidence(dataStore, redactedAnalysis, redactedGood, redactedBad)
 	if err != nil {
 		return err
 	}
@@ -189,7 +187,7 @@ func ImportDiagnostic(dataStore *store.Store, bundlePath string) (string, []byte
 	if err := decodeStrict(entries["certificate.json"], &certificate); err != nil {
 		return "", nil, fmt.Errorf("decode diagnostic certificate: %w", err)
 	}
-	if result := verifyCertificateValue(certificate, &analysis); !result.Valid {
+	if result := verifyCertificateValue(certificate, &analysis, &good, &bad); !result.Valid {
 		return "", nil, fmt.Errorf("diagnostic certificate is invalid: %s", result.Error)
 	}
 	var structured report.AnalysisReport
@@ -374,35 +372,4 @@ func validDiagnosticID(value string) bool {
 		return false
 	}
 	return !strings.Contains(value, "..")
-}
-
-func verifyCertificateValue(certificate Certificate, analysis *model.Analysis) VerificationResult {
-	if certificate.Format != "worldbisect.causal-certificate.v1" || certificate.Payload.ID != analysis.ID {
-		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate identity mismatch"}
-	}
-	if certificate.Payload.Status != analysis.Status {
-		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate status mismatch"}
-	}
-	key, err := base64.RawStdEncoding.DecodeString(certificate.PublicKey)
-	if err != nil || len(key) != ed25519.PublicKeySize {
-		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "invalid embedded public key"}
-	}
-	signature, err := base64.RawStdEncoding.DecodeString(certificate.Signature)
-	if err != nil || len(signature) != ed25519.SignatureSize {
-		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "invalid certificate signature"}
-	}
-	payload, err := json.Marshal(certificate.Payload)
-	if err != nil {
-		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate payload could not be encoded"}
-	}
-	expected, err := json.Marshal(analysis)
-	if err != nil || !bytes.Equal(payload, expected) {
-		return VerificationResult{Valid: false, AnalysisID: analysis.ID, Error: "certificate payload does not match analysis"}
-	}
-	valid := ed25519.Verify(ed25519.PublicKey(key), payload, signature)
-	result := VerificationResult{Valid: valid, AnalysisID: analysis.ID, Status: string(analysis.Status)}
-	if !valid {
-		result.Error = "signature verification failed"
-	}
-	return result
 }


### PR DESCRIPTION
## Problem

A signed causal result was previously tied to the full embedded analysis payload. That made long-term, independent verification difficult: certificates were not explicit about their evidence boundary, trust model, or next operator action.

## What changed

This PR implements #15 with a versioned, offline-verifiable certificate contract:

- Adds `worldbisect.causal-certificate.v2`.
- Signs deterministic claims instead of embedding raw analysis evidence.
- Includes SHA-256 digests for the good capture, bad capture, experiment set, and factor set.
- Keeps raw command output, workspace content, factor values, and experiment details out of v2 certificates.
- Reports `format`, `model`, `trust`, `evidence`, and `next_action` for readable offline verification.
- Supports an independently retained public key via `--public-key`.
- Returns a non-zero CLI exit code when verification fails.
- Keeps valid v1 certificates readable with an explicit legacy limitation.
- Updates diagnostic bundle export/import and the end-user guide.

## Verification behavior

```text
valid: true
trust: embedded key not independently trusted
next_action: compare the evidence hashes with the retained captures and review the model boundaries
```

Passing `--public-key` changes the trust result to an independently matched trust root. Any change to signed claims, evidence hashes, or the signature fails verification.

## Security and compatibility boundaries

- The embedded key proves integrity, but not ownership or organizational trust.
- The certificate does not authorize remediation or replace review of the original evidence.
- v1 certificates remain readable, but cannot provide v2 evidence hashes.
- Diagnostic bundles verify the certificate against their redacted analysis and captures before persistence.

## Tests

All checks passed locally in WSL with Go 1.25:

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `WORLDBISECT_E2E_RACE=1 ./scripts/e2e.sh`

Additional regression coverage verifies:

- v2 round-trip and trusted-key verification
- no secret-bearing/raw evidence leakage
- tampered claims are rejected
- valid v1 certificates remain readable

GitHub checks are green: `validate`, `analyze`, `arm64-runtime`, and `CodeQL`.

Closes #15
