### PR TITLE
fix: make diagnostic SARIF uploadable

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -84,10 +84,28 @@ type sarifRule struct {
 }
 
 type sarifResult struct {
-	RuleID     string         `json:"ruleId"`
-	Level      string         `json:"level"`
-	Message    sarifText      `json:"message"`
-	Properties map[string]any `json:"properties"`
+	RuleID     string          `json:"ruleId"`
+	Level      string          `json:"level"`
+	Message    sarifText       `json:"message"`
+	Locations  []sarifLocation `json:"locations"`
+	Properties map[string]any  `json:"properties"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           sarifRegion           `json:"region"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
 }
 
 type sarifText struct {
@@ -268,7 +286,14 @@ func SARIF(value *model.Analysis, links OutputLinks) ([]byte, error) {
 	if links.ReportURL != "" {
 		properties["report_url"] = links.ReportURL
 	}
-	result := sarifResult{RuleID: ruleID, Level: sarifLevel(value.Status), Message: sarifText{Text: report.Explanation}, Properties: properties}
+	result := sarifResult{
+		RuleID: ruleID, Level: sarifLevel(value.Status), Message: sarifText{Text: report.Explanation},
+		Locations: []sarifLocation{{PhysicalLocation: sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{URI: "worldbisect://analysis/" + report.AnalysisID},
+			Region:           sarifRegion{StartLine: 1},
+		}}},
+		Properties: properties,
+	}
 	document := sarifDocument{
 		Version: "2.1.0",
 		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -163,6 +163,22 @@ func TestJUnitAndSARIFContractsCoverStatuses(t *testing.T) {
 			if result.RuleID != "worldbisect/"+string(status) || result.Properties["status"] != string(status) {
 				t.Fatalf("invalid SARIF result: %s", sarif)
 			}
+			var locationDocument struct {
+				Runs []struct {
+					Results []struct {
+						Locations []struct {
+							PhysicalLocation struct {
+								ArtifactLocation struct {
+									URI string `json:"uri"`
+								} `json:"artifactLocation"`
+							} `json:"physicalLocation"`
+						} `json:"locations"`
+					} `json:"results"`
+				} `json:"runs"`
+			}
+			if err := json.Unmarshal(sarif, &locationDocument); err != nil || len(locationDocument.Runs[0].Results[0].Locations) != 1 || locationDocument.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI != "worldbisect://analysis/ana_"+strings.ToLower(string(status)) {
+				t.Fatalf("SARIF location missing or unstable: %s", sarif)
+			}
 			if strings.Contains(string(junit), "supersecret") || strings.Contains(string(sarif), "supersecret") {
 				t.Fatal("diagnostic formats exposed secret text")
 			}


### PR DESCRIPTION
## Problem

The `main` CI `validate` job completed successfully, but the follow-up
`upload-diagnostic-sarif` job failed while processing the generated report:

```text
locationFromSarifResult: expected at least one location
```

The SARIF result described the WorldBisect analysis but did not identify a
location. GitHub Code Scanning therefore rejected the otherwise valid SARIF
document.

## Fix

- Adds one stable, non-sensitive SARIF location to every analysis result:
  `worldbisect://analysis/<analysis-id>`.
- Anchors the finding at line 1, satisfying the SARIF location contract without
  exposing workspace paths or customer evidence.
- Adds regression coverage for location presence and deterministic URI output.

## Scope and compatibility

- No causal-analysis behavior or proof status semantics changed.
- No raw command output, workspace content, factor values, or secrets are added
  to SARIF.
- Existing SARIF rule IDs, levels, messages, properties, and report links are
  preserved.
- The change is limited to the shared report generator and its tests.

## Validation

Executed locally in WSL with Go 1.25:

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `WORLDBISECT_E2E_RACE=1 ./scripts/e2e.sh`

GitHub checks for this PR are green:

- `validate`
- `analyze`
- `arm64-runtime`
- `CodeQL`

The SARIF upload job is intentionally skipped on pull requests and will run
on `main` after merge. This fix addresses the exact failure observed in the
previous `main` run.
