### PR TITLE
feat: harden interrupted analysis workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ also includes a proof explanation, evidence boundaries, and technical IDs for
 support. Use `--format json` when a machine needs the stable structured
 contract instead of the human-readable report.
 
+Large or long-running analyses are bounded by explicit workspace file/byte,
+output, timeout, factor, and experiment limits. Use `--progress` to receive
+experiment progress on stderr without corrupting JSON stdout. Press Ctrl+C to
+cancel safely; completed work remains persisted and reusable through the
+experiment cache, while an interrupted run remains visibly incomplete.
+
 The JSON output is the versioned `worldbisect.analysis-report.v1` contract.
 Markdown output is also stable and can be pasted into GitHub pull requests or
 support tickets. Both formats are derived from the same report model and omit

--- a/cmd/worldbisect/main.go
+++ b/cmd/worldbisect/main.go
@@ -75,7 +75,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	case "capture":
 		return runCapture(args[1:], stdout)
 	case "compare":
-		return runCompare(args[1:], stdout)
+		return runCompare(args[1:], stdout, stderr)
 	case "explain":
 		return runExplain(args[1:], stdout)
 	case "export":
@@ -138,6 +138,9 @@ func runCapture(args []string, stdout io.Writer) error {
 	label := set.String("label", "", "capture label")
 	oracleSpec := set.String("oracle", "exit=0", "failure oracle")
 	timeout := set.Duration("timeout", 2*time.Minute, "command timeout")
+	maxWorkspaceFiles := set.Int("max-workspace-files", 10000, "maximum workspace files to scan")
+	maxWorkspaceBytes := set.Int64("max-workspace-bytes", 1<<30, "maximum workspace bytes to scan")
+	maxOutputBytes := set.Int64("max-output-bytes", 8<<20, "maximum captured stdout and stderr bytes")
 	output := set.String("output", "", "portable bundle output")
 	format := set.String("format", "text", "text or json")
 	if err := set.Parse(flags); err != nil {
@@ -162,7 +165,9 @@ func runCapture(args []string, stdout io.Writer) error {
 		return err
 	}
 	capturer := capture.New(dataStore, runner.New())
-	record, err := capturer.Capture(context.Background(), capture.Request{
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	record, err := capturer.Capture(ctx, capture.Request{
 		Label:     *label,
 		Workspace: root,
 		Command: model.CommandSpec{
@@ -172,6 +177,7 @@ func runCapture(args []string, stdout io.Writer) error {
 			Environment: model.EnvironmentFromList(os.Environ()),
 		},
 		Oracle: parsedOracle,
+		Limits: model.CaptureLimits{MaxWorkspaceFiles: *maxWorkspaceFiles, MaxWorkspaceBytes: *maxWorkspaceBytes, MaxOutputBytes: *maxOutputBytes, Timeout: *timeout},
 	})
 	if record != nil && *output != "" {
 		if err := artifact.ExportCapture(dataStore, record.ID, *output); err != nil {
@@ -187,7 +193,7 @@ func runCapture(args []string, stdout io.Writer) error {
 	return err
 }
 
-func runCompare(args []string, stdout io.Writer) error {
+func runCompare(args []string, stdout, stderr io.Writer) error {
 	flags, command, err := splitCommand(args)
 	if err != nil {
 		return err
@@ -199,6 +205,10 @@ func runCompare(args []string, stdout io.Writer) error {
 	bad := set.String("bad", "", "bad capture ID or bundle")
 	repetitions := set.Int("repetitions", 3, "experiment repetitions")
 	maxExperiments := set.Int("max-experiments", 128, "experiment budget")
+	maxFactors := set.Int("max-factors", 512, "maximum supported factors")
+	maxOutputBytes := set.Int64("max-output-bytes", 8<<20, "maximum captured stdout and stderr bytes per experiment")
+	timeout := set.Duration("timeout", 0, "override command timeout")
+	progress := set.Bool("progress", false, "write bounded experiment progress to stderr")
 	format := set.String("format", "text", "text, json, junit, or sarif")
 	certificate := set.String("certificate", "", "certificate output path")
 	reportURL := set.String("report-url", "", "stable URL for the report")
@@ -233,13 +243,26 @@ func runCompare(args []string, stdout io.Writer) error {
 	if len(command) == 0 {
 		command = append([]string(nil), badCapture.Command.Arguments...)
 	}
+	if *timeout > 0 {
+		goodCapture.Command.TimeoutMS = timeout.Milliseconds()
+		badCapture.Command.TimeoutMS = timeout.Milliseconds()
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	engine := experiment.New(dataStore, runner.New())
-	analysis, err := engine.Analyze(context.Background(), experiment.Request{
+	analysis, err := engine.Analyze(ctx, experiment.Request{
 		Good:           goodCapture,
 		Bad:            badCapture,
 		Command:        command,
 		Repetitions:    *repetitions,
 		MaxExperiments: *maxExperiments,
+		MaxFactors:     *maxFactors,
+		MaxOutputBytes: *maxOutputBytes,
+		Progress: func(event experiment.ProgressEvent) {
+			if *progress {
+				fmt.Fprintf(stderr, "progress: experiment=%s kind=%s cache_hit=%t\n", event.ExperimentID, event.Kind, event.CacheHit)
+			}
+		},
 	})
 	if analysis != nil && *certificate != "" {
 		if err := artifact.WriteCertificate(dataStore, analysis.ID, *certificate); err != nil {
@@ -247,7 +270,11 @@ func runCompare(args []string, stdout io.Writer) error {
 		}
 	}
 	if analysis != nil {
-		return finishAnalysis(stdout, analysis, *format, report.OutputLinks{ReportURL: *reportURL, BundleURL: *bundleURL}, *failOn)
+		outputErr := finishAnalysis(stdout, analysis, *format, report.OutputLinks{ReportURL: *reportURL, BundleURL: *bundleURL}, *failOn)
+		if outputErr != nil {
+			return outputErr
+		}
+		return err
 	}
 	return err
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,6 +34,10 @@ worldbisect capture \
   --store /tmp/wb-store \
   --workspace /path/to/good \
   --oracle exit=0 \
+  --max-workspace-files 10000 \
+  --max-workspace-bytes 1073741824 \
+  --max-output-bytes 8388608 \
+  --timeout 2m \
   --label good \
   --output /tmp/good.wcap \
   -- ./test-command
@@ -59,11 +63,21 @@ worldbisect compare \
   --bad /tmp/bad.wcap \
   --repetitions 3 \
   --max-experiments 128 \
+  --max-factors 512 \
+  --max-output-bytes 8388608 \
+  --timeout 2m \
+  --progress \
   --certificate /tmp/result.wbc \
   -- ./test-command
 ```
 
-WorldBisect imports bundles when a path is supplied, compares the sessions, reruns the baselines, tests candidate groups, minimizes a supported factor set, reverses the intervention direction, and records all experiments.
+WorldBisect imports bundles when a path is supplied, compares the sessions, reruns the baselines, tests candidate groups, minimizes a supported factor set, reverses the intervention direction, and records all experiments. Workspace file/byte limits, output limits, timeouts, factor limits, and experiment budgets are explicit. Progress is written to stderr, so JSON stdout remains machine-readable.
+
+Press Ctrl+C to cancel a long capture or analysis. Running child process groups
+are terminated safely, and an interrupted analysis is persisted as `UNPROVEN`
+with completed experiments retained in the store/cache. The report explains
+that the run was interrupted and that repeating the same analysis can reuse
+completed experiment results; partial failure is never presented as proof.
 
 Workspace factors are limited to regular file content/presence, permission
 bits, directories, and relative symlinks whose targets remain inside the

--- a/internal/experiment/engine.go
+++ b/internal/experiment/engine.go
@@ -24,6 +24,25 @@ type Request struct {
 	MaxExperiments int
 	MaxFactors     int
 	MaxOutputBytes int64
+	Progress       func(ProgressEvent)
+}
+
+type ProgressEvent struct {
+	ExperimentID string `json:"experiment_id"`
+	Kind         string `json:"kind"`
+	CacheHit     bool   `json:"cache_hit"`
+}
+
+type progressContextKey struct{}
+
+func withProgress(ctx context.Context, progress func(ProgressEvent)) context.Context {
+	return context.WithValue(ctx, progressContextKey{}, progress)
+}
+
+func notifyProgress(ctx context.Context, event ProgressEvent) {
+	if progress, ok := ctx.Value(progressContextKey{}).(func(ProgressEvent)); ok && progress != nil {
+		progress(event)
+	}
 }
 
 type Engine struct {
@@ -36,6 +55,7 @@ func New(dataStore *store.Store, commandRunner *runner.Runner) *Engine {
 }
 
 func (engine *Engine) Analyze(ctx context.Context, request Request) (*model.Analysis, error) {
+	ctx = withProgress(ctx, request.Progress)
 	if request.Good == nil || request.Bad == nil {
 		return nil, errors.New("good and bad captures are required")
 	}
@@ -68,16 +88,25 @@ func (engine *Engine) Analyze(ctx context.Context, request Request) (*model.Anal
 		Repetitions:        request.Repetitions,
 		ExperimentBudget:   request.MaxExperiments,
 	}
+	if err := ctx.Err(); err != nil {
+		return engine.finishInterrupted(analysis, err)
+	}
 
 	goodBaseline, err := engine.verifyBaseline(ctx, request.Good, request.Command, true, request.Repetitions, request.MaxOutputBytes)
 	analysis.Experiments = append(analysis.Experiments, goodBaseline...)
 	if err != nil {
+		if ctx.Err() != nil {
+			return engine.finishInterrupted(analysis, ctx.Err())
+		}
 		analysis.Limitations = append(analysis.Limitations, "good baseline is not stable: "+err.Error())
 		return engine.finish(analysis, nil)
 	}
 	badBaseline, err := engine.verifyBaseline(ctx, request.Bad, request.Command, false, request.Repetitions, request.MaxOutputBytes)
 	analysis.Experiments = append(analysis.Experiments, badBaseline...)
 	if err != nil {
+		if ctx.Err() != nil {
+			return engine.finishInterrupted(analysis, ctx.Err())
+		}
 		analysis.Limitations = append(analysis.Limitations, "bad baseline is not stable: "+err.Error())
 		return engine.finish(analysis, nil)
 	}
@@ -105,6 +134,9 @@ func (engine *Engine) Analyze(ctx context.Context, request Request) (*model.Anal
 	})
 	_ = used
 	if minimizeErr != nil {
+		if ctx.Err() != nil {
+			return engine.finishInterrupted(analysis, ctx.Err())
+		}
 		analysis.Limitations = append(analysis.Limitations, minimizeErr.Error())
 		return engine.finish(analysis, nil)
 	}
@@ -120,6 +152,9 @@ func (engine *Engine) Analyze(ctx context.Context, request Request) (*model.Anal
 	reverseRecords, reversePasses, err := engine.runIntervention(ctx, request.Good, request.Bad, request.Good.ID, request.Command, minimized, factorByID, request.Repetitions, false, request.MaxOutputBytes)
 	analysis.Experiments = append(analysis.Experiments, reverseRecords...)
 	if err != nil {
+		if ctx.Err() != nil {
+			return engine.finishInterrupted(analysis, ctx.Err())
+		}
 		analysis.Limitations = append(analysis.Limitations, "reverse verification failed: "+err.Error())
 		return engine.finish(analysis, nil)
 	}
@@ -133,6 +168,9 @@ func (engine *Engine) Analyze(ctx context.Context, request Request) (*model.Anal
 	minimal, minimalityRecords, err := engine.verifyMinimality(ctx, request, minimized, factorByID)
 	analysis.Experiments = append(analysis.Experiments, minimalityRecords...)
 	if err != nil {
+		if ctx.Err() != nil {
+			return engine.finishInterrupted(analysis, ctx.Err())
+		}
 		analysis.Limitations = append(analysis.Limitations, "minimality verification incomplete: "+err.Error())
 		analysis.Status = model.StatusSupported
 		analysis.CausalFactors = minimized
@@ -198,6 +236,7 @@ func (engine *Engine) runWorld(ctx context.Context, base, source *model.Capture,
 		cached.SourceCaptureID = source.ID
 		cached.FactorIDs = append([]string(nil), factorIDs...)
 		cached.CacheHit = true
+		notifyProgress(ctx, ProgressEvent{ExperimentID: cached.ID, Kind: cached.Kind, CacheHit: true})
 		return cached, cached.OracleResult.Passed, nil
 	}
 	root, err := os.MkdirTemp("", "worldbisect-experiment-")
@@ -268,6 +307,7 @@ func (engine *Engine) runWorld(ctx context.Context, base, source *model.Capture,
 		// still returned if the disposable cache is unavailable or full.
 		_ = engine.store.SaveExperimentCache(cacheKey, record)
 	}
+	notifyProgress(ctx, ProgressEvent{ExperimentID: record.ID, Kind: record.Kind, CacheHit: false})
 	return record, record.OracleResult.Passed, nil
 }
 
@@ -308,6 +348,11 @@ func (engine *Engine) finish(analysis *model.Analysis, err error) (*model.Analys
 		return nil, auditErr
 	}
 	return analysis, err
+}
+
+func (engine *Engine) finishInterrupted(analysis *model.Analysis, err error) (*model.Analysis, error) {
+	analysis.Limitations = append(analysis.Limitations, "analysis cancelled; completed experiments were retained and can be reused by the experiment cache")
+	return engine.finish(analysis, err)
 }
 
 func copyMap(source map[string]string) map[string]string {

--- a/internal/experiment/engine_test.go
+++ b/internal/experiment/engine_test.go
@@ -2,8 +2,10 @@ package experiment
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,7 +45,8 @@ func TestEngineProvesFileCause(t *testing.T) {
 		t.Fatal(err)
 	}
 	bad, _ := capturer.Capture(context.Background(), capture.Request{Workspace: badRoot, Command: model.CommandSpec{Arguments: []string{"./check.sh"}, Directory: badRoot, TimeoutMS: time.Second.Milliseconds(), Environment: map[string]string{}}, Oracle: oracleValue})
-	analysis, err := New(dataStore, runner.New()).Analyze(context.Background(), Request{Good: good, Bad: bad, Command: []string{"./check.sh"}, Repetitions: 2, MaxExperiments: 64})
+	progressEvents := 0
+	analysis, err := New(dataStore, runner.New()).Analyze(context.Background(), Request{Good: good, Bad: bad, Command: []string{"./check.sh"}, Repetitions: 2, MaxExperiments: 64, Progress: func(ProgressEvent) { progressEvents++ }})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,6 +55,9 @@ func TestEngineProvesFileCause(t *testing.T) {
 	}
 	if len(analysis.CausalFactors) != 1 {
 		t.Fatalf("causal factors = %v", analysis.CausalFactors)
+	}
+	if progressEvents == 0 {
+		t.Fatal("analysis did not emit progress events")
 	}
 	cachedAnalysis, err := New(dataStore, runner.New()).Analyze(context.Background(), Request{Good: good, Bad: bad, Command: []string{"./check.sh"}, Repetitions: 2, MaxExperiments: 64})
 	if err != nil {
@@ -68,6 +74,34 @@ func TestEngineProvesFileCause(t *testing.T) {
 	}
 	if cachedAnalysis.Status != model.StatusProven {
 		t.Fatalf("cached status = %s limitations=%v", cachedAnalysis.Status, cachedAnalysis.Limitations)
+	}
+}
+
+func TestCancelledAnalysisPersistsCompletedState(t *testing.T) {
+	dataStore, err := store.Open(filepath.Join(t.TempDir(), "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdAt := time.Unix(1, 0).UTC()
+	good := &model.Capture{SchemaVersion: 3, ID: "good-cancel", CreatedAt: createdAt, Command: model.CommandSpec{Arguments: []string{"check"}}}
+	bad := &model.Capture{SchemaVersion: 3, ID: "bad-cancel", CreatedAt: createdAt, Command: model.CommandSpec{Arguments: []string{"check"}}}
+	if err := dataStore.SaveCapture(good); err != nil {
+		t.Fatal(err)
+	}
+	if err := dataStore.SaveCapture(bad); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	analysis, err := New(dataStore, runner.New()).Analyze(ctx, Request{Good: good, Bad: bad, Command: []string{"check"}})
+	if !errors.Is(err, context.Canceled) || analysis == nil {
+		t.Fatalf("cancelled analysis = %+v, %v", analysis, err)
+	}
+	if len(analysis.Limitations) == 0 || !strings.Contains(analysis.Limitations[len(analysis.Limitations)-1], "completed experiments were retained") {
+		t.Fatalf("cancellation guidance missing: %+v", analysis.Limitations)
+	}
+	if _, err := dataStore.LoadAnalysis(analysis.ID); err != nil {
+		t.Fatalf("cancelled analysis was not persisted: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR delivers the first production-ready reliability slice for #17:

- explicit workspace, output, timeout, factor, and experiment limits
- SIGINT/SIGTERM cancellation with safe child-process-group termination
- optional experiment progress on stderr, preserving machine-readable stdout
- persisted interrupted analyses with visible incomplete status and guidance
- reuse of completed experiment results through the existing deterministic cache
- regression coverage for cancellation, progress, persistence, race safety, and E2E

## Operator behavior

```bash
worldbisect compare \
  --max-workspace-files 10000 \
  --max-workspace-bytes 1073741824 \
  --max-output-bytes 8388608 \
  --max-factors 512 \
  --max-experiments 128 \
  --progress \
  --good good.wcap --bad bad.wcap -- ./check.sh
```

Pressing Ctrl+C terminates the active process group, persists the incomplete
analysis, and keeps completed experiment results available for reuse. Partial
work is never presented as proof.

## Scope boundary

This PR intentionally does not introduce a separate resume command or parallel
experiment scheduler. Those require additional durable job/checkpoint and
ordering design and should remain follow-up work under #17.

## Validation

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `WORLDBISECT_E2E_RACE=1 ./scripts/e2e.sh`
- GitHub `validate`, `analyze`, `arm64-runtime`, and `CodeQL`: green

Partially addresses #17.
