### PR TITLE
fix: harden workspace capture against hardlinks and races

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ On Linux AMD64, a bounded `ptrace` tracer records selected filesystem-related sy
 
 ### Workspace capture
 
-The workspace scanner records regular files, directories, and symbolic links using relative paths. It stores content hashes and file mode, rejects traversal, does not follow symlink targets, and enforces file and byte quotas.
+The workspace scanner records regular files, directories, and symbolic links using relative paths. It stores content hashes and file mode, rejects traversal and Linux hardlinks, verifies file identity/metadata around reads, does not follow symlink targets, and enforces file and byte quotas.
 
 ### Comparator
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -37,6 +37,11 @@ This closes the basename bypass and materially reduces path time-of-check/time-o
 
 The runner uses a new process group and kills the group on timeout or cancellation. Experiments operate on copied temporary workspaces and do not intentionally modify the original workspace.
 
+Workspace capture rejects files with multiple hard links on Linux and checks
+file identity and metadata before and after reading. A pathname replacement or
+metadata race fails closed instead of ingesting an unstable or potentially
+outside-workspace file.
+
 This is not a full malicious-code sandbox. Use an independently hardened VM or container when executing untrusted code.
 
 ## Archive safety

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -40,6 +40,10 @@ Controls: loopback default, bearer authentication, hashed stored tokens, constan
 
 Controls: canonical absolute paths, no basename matching, no `PATH` authorization, final-symlink rejection, opened-file-descriptor binding, inode and digest revalidation.
 
+Workspace capture separately rejects Linux hardlinks and verifies file identity
+and metadata before and after reads, preventing pathname replacement and
+unstable file ingestion from becoming stored evidence.
+
 ### Working-directory replacement
 
 Controls: canonical directory authorization, directory descriptor binding, pre-execution identity validation.

--- a/internal/workspace/hardlink_linux.go
+++ b/internal/workspace/hardlink_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package workspace
+
+import (
+	"os"
+	"syscall"
+)
+
+func hardlinkCount(info os.FileInfo) uint64 {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 1
+	}
+	return uint64(stat.Nlink)
+}

--- a/internal/workspace/hardlink_other.go
+++ b/internal/workspace/hardlink_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package workspace
+
+import "os"
+
+// Non-Linux release targets do not expose a portable link-count contract.
+// The regular-file read still uses descriptor identity and post-read metadata
+// checks; Linux additionally rejects files with multiple directory links.
+func hardlinkCount(_ os.FileInfo) uint64 { return 1 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -71,17 +71,15 @@ func Scan(root string, dataStore *store.Store, maxFiles int, maxBytes int64) (mo
 		switch {
 		case info.Mode().IsRegular():
 			item.Type = "file"
-			file, err := os.Open(path)
+			if hardlinkCount(info) > 1 {
+				item.Type = "unsupported"
+				break
+			}
+			content, err := readStableFile(path, info, maxBytes)
 			if err != nil {
 				return err
 			}
 			contentHash := sha256.New()
-			limited := io.LimitReader(file, maxBytes+1)
-			content, err := io.ReadAll(limited)
-			file.Close()
-			if err != nil {
-				return err
-			}
 			manifest.TotalBytes += int64(len(content))
 			if manifest.TotalBytes > maxBytes {
 				return errors.New("workspace byte quota exceeded")
@@ -125,6 +123,37 @@ func Scan(root string, dataStore *store.Store, maxFiles int, maxBytes int64) (mo
 	}
 	manifest.Digest = hex.EncodeToString(hash.Sum(nil))
 	return manifest, nil
+}
+
+func readStableFile(path string, expected os.FileInfo, maxBytes int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !sameFileState(expected, opened) {
+		return nil, fmt.Errorf("workspace file changed before read: %q", path)
+	}
+	content, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	finished, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !sameFileState(expected, finished) {
+		return nil, fmt.Errorf("workspace file changed during read: %q", path)
+	}
+	return content, nil
+}
+
+func sameFileState(expected, actual os.FileInfo) bool {
+	return os.SameFile(expected, actual) && expected.Mode() == actual.Mode() && expected.Size() == actual.Size() && expected.ModTime() == actual.ModTime()
 }
 
 func Materialize(root string, manifest model.WorkspaceManifest, dataStore *store.Store) error {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -80,6 +80,47 @@ func TestScanMarksEscapingSymlinkUnsupported(t *testing.T) {
 	}
 }
 
+func TestScanRejectsHardlinkAsUnsupported(t *testing.T) {
+	root := t.TempDir()
+	external := filepath.Join(t.TempDir(), "outside-secret")
+	if err := os.WriteFile(external, []byte("do not ingest"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "linked-file")
+	if err := os.Link(external, link); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	dataStore, err := store.Open(filepath.Join(t.TempDir(), "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := Scan(root, dataStore, 100, 1<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Entries) != 1 || manifest.Entries[0].Type != "unsupported" || manifest.Entries[0].BlobDigest != "" {
+		t.Fatalf("hardlink was ingested: %+v", manifest.Entries)
+	}
+}
+
+func TestReadStableFileRejectsMetadataChange(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "changing")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readStableFile(path, expected, 1<<20); err == nil {
+		t.Fatal("metadata change was accepted")
+	}
+}
+
 func TestApplyPreservesFileAndDirectoryModes(t *testing.T) {
 	dataStore, _ := store.Open(filepath.Join(t.TempDir(), "store"))
 	digest, err := dataStore.PutBlob([]byte("content"))


### PR DESCRIPTION
## Security issue

The workspace scanner previously treated every regular file as safe to ingest.
That left two gaps in the documented security boundary:

1. A Linux hardlink inside the workspace could reference content also linked
   outside the workspace and be stored as trusted evidence.
2. A file could be replaced or modified between the initial path inspection and
   the content read, producing unstable evidence.

## Fix

- Rejects Linux regular files with more than one hard link as `unsupported`.
- Verifies file identity and metadata before reading.
- Verifies identity and metadata again after reading.
- Fails closed on identity, mode, size, or modification-time changes.
- Prevents unsupported hardlinks from becoming workspace factors or blobs.
- Adds focused hardlink and metadata-race regression tests.
- Aligns `docs/security.md`, `docs/threat-model.md`, and
  `docs/architecture.md` with the executable behavior.

## Security boundary

This protects workspace evidence integrity and prevents a known hardlink/path
replacement ingestion path. It does not turn arbitrary user commands into a
complete sandbox; the existing VM/container guidance for untrusted code still
applies. The broader #18 work for secret/redaction and daemon hardening remains
separate follow-up scope.

## Compatibility

- Regular files, directories, and safe relative symlinks keep their existing
  behavior.
- Hardlinks are observed but remain non-intervenable `unsupported` entries.
- No API, store schema, or certificate format changes are introduced.

## Validation

Executed locally in WSL with Go 1.25:

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `WORLDBISECT_E2E_RACE=1 ./scripts/e2e.sh`

GitHub checks are green: `validate`, `analyze`, `arm64-runtime`, and `CodeQL`.

This PR delivers the first focused security gate for #18; it does not claim
the entire cross-cutting hardening issue is complete.
