### PR TITLE
fix(ci): make SARIF upload compatible with Code Scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,13 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Checkout repository for Code Scanning context
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download diagnostic reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: worldbisect-diagnostic-reports
           path: build/diagnostics
-      - name: Checkout repository for Code Scanning context
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prepare SARIF for Code Scanning
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      contents: read
       security-events: write
     steps:
       - name: Download diagnostic reports
@@ -74,10 +75,31 @@ jobs:
         with:
           name: worldbisect-diagnostic-reports
           path: build/diagnostics
+      - name: Checkout repository for Code Scanning context
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Prepare SARIF for Code Scanning
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          source = Path("build/diagnostics/analysis.sarif")
+          target = Path("build/diagnostics/github-code-scanning.sarif")
+          document = json.loads(source.read_text(encoding="utf-8"))
+          for run in document.get("runs", []):
+              for result in run.get("results", []):
+                  # WorldBisect locations identify an analysis, not a source file.
+                  # GitHub Code Scanning accepts only file/relative artifact URIs,
+                  # so keep the canonical SARIF unchanged and upload this
+                  # analysis-level projection without a misleading file location.
+                  result.pop("locations", None)
+          target.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+          PY
       - name: Upload SARIF findings
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
-          sarif_file: build/diagnostics/analysis.sarif
+          sarif_file: build/diagnostics/github-code-scanning.sarif
 
   arm64-runtime:
     runs-on: ubuntu-22.04-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,17 @@ jobs:
           document = json.loads(source.read_text(encoding="utf-8"))
           for run in document.get("runs", []):
               for result in run.get("results", []):
-                  # WorldBisect locations identify an analysis, not a source file.
-                  # GitHub Code Scanning accepts only file/relative artifact URIs,
-                  # so keep the canonical SARIF unchanged and upload this
-                  # analysis-level projection without a misleading file location.
-                  result.pop("locations", None)
+                  # WorldBisect's canonical location identifies an analysis, not
+                  # a source file. Code Scanning requires a relative/file URI and
+                  # at least one location, so point the upload projection at the
+                  # generated diagnostic artifact while keeping the canonical
+                  # SARIF unchanged.
+                  result["locations"] = [{
+                      "physicalLocation": {
+                          "artifactLocation": {"uri": "build/diagnostics/analysis.sarif"},
+                          "region": {"startLine": 1},
+                      }
+                  }]
           target.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
           PY
       - name: Upload SARIF findings


### PR DESCRIPTION
## Summary

Fixes the failing upload-diagnostic-sarif job on main.

The failure had two independent workflow causes:

1. The canonical WorldBisect SARIF uses worldbisect:// analysis locations, which GitHub Code Scanning rejects because the upload checkout uses the file URI scheme.
2. The upload job downloaded the diagnostic artifact before actions/checkout; checkout then removed the downloaded file.

## Changes

- Keep the canonical WorldBisect SARIF contract unchanged.
- Checkout the repository before downloading diagnostic reports.
- Grant the upload job contents: read permission.
- Generate a Code Scanning-specific SARIF projection with a valid relative artifact location.
- Upload only the projection to Code Scanning.

The public report formats and their existing tests are unchanged.

## Validation

- Workflow YAML parsed successfully with PyYAML.
- git diff --check passed.
- SARIF projection smoke test passed.
- PR checks passed: Go tests, race detector, end-to-end tests, release gate, native ARM64 validation, and CodeQL.
- The real push path was verified with workflow dispatch:
  - validate: success
  - arm64-runtime: success
  - upload-diagnostic-sarif: success
  - Workflow run: https://github.com/ClusterPilot-System/worldbisect/actions/runs/32487393678

This PR is ready for review and merge into main.
