### PR TITLE
harden(release): enforce immutable release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Major compatibility tags such as v1 deliberately remain movable and
+      # must not create a GitHub Release. Only full SemVer tags are releases.
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag:
@@ -113,7 +115,12 @@ jobs:
           if ! grep -q '[^[:space:]]' "$notes"; then
             printf 'WorldBisect %s\n' "$VERSION" > "$notes"
           fi
+          # Immutable Releases locks assets and the release tag at publication
+          # time. Upload every asset to a draft first, then publish once the
+          # draft is complete.
           gh release create "$TAG" dist/* \
             --title "WorldBisect ${VERSION}" \
             --notes-file "$notes" \
+            --draft \
             --verify-tag
+          gh release edit "$TAG" --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and the project follows Semantic Versioning for its public contracts.
 
+## [Unreleased]
+
+### Security
+
+- Future GitHub releases are published through the repository's Immutable
+  Releases setting using a draft-first asset upload flow.
+- Documented the moving `v1` Action compatibility tag separately from full
+  commit-SHA pins and archive/attestation verification for security-critical
+  workflows.
+
 ## [1.1.1]
 
 ### Changed

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -33,7 +33,11 @@ The Go module intentionally has no third-party module dependencies. Release tool
 
 ## Release provenance
 
-Official releases are built from immutable tags by GitHub Actions. The release workflow:
+Official releases are built by GitHub Actions. Repository-level GitHub Immutable
+Releases are enabled for future publications; the workflow uploads assets to a
+draft before publication locks the release tag and assets. Earlier published
+releases are retained as historical evidence and are not rewritten because
+GitHub does not apply release immutability retroactively. The release workflow:
 
 1. validates the source tree;
 2. runs unit, race, integration, and end-to-end tests;
@@ -42,3 +46,7 @@ Official releases are built from immutable tags by GitHub Actions. The release w
 5. publishes a GitHub artifact attestation backed by GitHub OIDC and Sigstore.
 
 Consumers should verify `SHA256SUMS` and the GitHub artifact attestation before installing release binaries.
+
+The `v1` Action tag is a moving compatible-release pointer, not a fixed trust
+root. Security-critical consumers must pin a reviewed full commit SHA and
+verify the architecture-matching archive digest and GitHub attestation.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ and pin the Action to a reviewed commit or immutable release:
 ```yaml
 - name: Diagnose workspace difference
   id: worldbisect
-  uses: ClusterPilot-System/worldbisect@v1.1.0
+  uses: ClusterPilot-System/worldbisect@v1
   with:
     command: ./check.sh
     good-workspace: demo/good
@@ -157,6 +157,45 @@ repository:
     # Optional explicit Linux AMD64 digest for v1.1.0:
     # sha256: 74602fb5a1894eaf63ef12178fa5d9ff53b6369a9277f17021c3733f18f7d757
 ```
+
+### Action trust pins
+
+`v1` is the maintained compatibility tag for the latest compatible 1.x Action
+release. It is intentionally movable and initially points to the reviewed
+`v1.1.1` release commit. Use it when receiving compatible updates matters more
+than pinning a single revision:
+
+```yaml
+uses: ClusterPilot-System/worldbisect@v1
+```
+
+For security-critical workflows, pin the Action to the full reviewed commit
+SHA and explicitly verify the release archive that it downloads. This example
+pins the `v1.1.1` Action commit and its Linux AMD64 archive:
+
+```yaml
+- uses: ClusterPilot-System/worldbisect@65e217a1e759bd35a0039d5dfcb17f8aebec01d2 # v1.1.1
+  with:
+    command: ./check.sh
+    good-workspace: demo/good
+    bad-workspace: demo/bad
+    version: 1.1.1
+    sha256: 5725bd04acdd9bedefddf899fd1bae19f914dd2d8db3d60eae4156d0324202c6
+```
+
+Use the matching architecture-specific SHA-256 from the release's
+`SHA256SUMS`; do not copy the AMD64 digest to an ARM64 runner. After download,
+verify GitHub provenance as well:
+
+```bash
+gh attestation verify worldbisect_1.1.1_linux_amd64.tar.gz \
+  --repo ClusterPilot-System/worldbisect
+```
+
+GitHub Immutable Releases are enabled for future published releases. GitHub
+does not retroactively lock earlier published releases, including `v1.0.0`,
+`v1.1.0`, and `v1.1.1`; preserve those historical tags and use their reviewed
+commit SHAs when an immutable reference is required.
 
 `good-workspace` is the relative path to the workspace where the command is
 known to pass. `bad-workspace` is the relative path to the workspace where the
@@ -306,6 +345,10 @@ Official release artifacts include:
 - SPDX SBOM;
 - `SHA256SUMS`;
 - GitHub artifact attestation.
+
+Full semantic release tags are published as immutable GitHub Releases. The
+moving `v1` compatibility tag is not a GitHub Release and is updated only to a
+reviewed compatible release commit.
 
 Verify checksums:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,15 @@ See `docs/security.md` and `docs/threat-model.md`.
 
 ## Release integrity
 
-Official releases are produced from immutable tags by GitHub Actions. Release artifacts include SHA-256 checksums, an SPDX SBOM, and a GitHub artifact attestation.
+Repository-level GitHub Immutable Releases are enabled for future official
+releases. A release is assembled as a draft, with all assets attached, and then
+published so its release tag and assets are locked by GitHub. Existing releases
+published before this setting (`v1.0.0`, `v1.1.0`, and `v1.1.1`) are retained
+without rewriting, because GitHub does not apply immutability retroactively.
+
+Official releases include SHA-256 checksums, an SPDX SBOM, and a GitHub artifact
+attestation. The `v1` Action tag is a moving compatibility tag; security-
+critical consumers should pin a full reviewed commit SHA and verify the matching
+release checksums and attestation.
 
 Consumers should verify both checksums and provenance before installation.

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -39,6 +39,8 @@ Protect `main` with a GitHub ruleset or branch-protection rule:
 ## Release
 
 - [ ] Tag is annotated or cryptographically signed.
+- [ ] GitHub Immutable Releases are enabled for this repository or enforced by the organization.
+- [ ] All release assets are attached to a draft before it is published and locked.
 - [ ] Release workflow completed successfully.
 - [ ] Release is neither draft nor prerelease.
 - [ ] `SHA256SUMS` verifies every published binary artifact.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -32,6 +32,9 @@
 ## GitHub
 
 - [ ] Actions are pinned to immutable commit SHAs.
+- [ ] GitHub Immutable Releases are enabled for the repository or organization.
+- [ ] Full release assets are uploaded to a draft before publishing the immutable release.
+- [ ] The `v1` compatibility tag points to the intended reviewed 1.x release commit.
 - [ ] Release workflow has minimum explicit permissions.
 - [ ] CodeQL is enabled.
 - [ ] Tag is immutable and points to the reviewed commit.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -188,26 +188,29 @@ SARIF result properties without embedding sensitive data.
 ## GitHub Action
 
 The repository exposes a composite action for Linux GitHub runners. It downloads
-the selected WorldBisect release only after verifying the caller-provided
-SHA-256, captures only the two explicitly selected workspace paths, and uploads
+the selected WorldBisect release only after verifying an explicit SHA-256 or the
+documented built-in digest for the official default release, captures only the
+two explicitly selected workspace paths, and uploads
 the Markdown/JSON/JUnit/SARIF reports, certificate, and redacted diagnostic
 bundle as one artifact. It never collects kubeconfigs, credentials, or other
 files outside those workspaces automatically.
 
 ```yaml
 - name: Diagnose workspace difference
-  uses: ClusterPilot-System/worldbisect@<commit-sha>
+  uses: ClusterPilot-System/worldbisect@65e217a1e759bd35a0039d5dfcb17f8aebec01d2 # v1.1.1
   with:
     command: ./ci/check.sh
     good-workspace: fixtures/good
     bad-workspace: fixtures/bad
-    version: 1.1.0
-    sha256: 74602fb5a1894eaf63ef12178fa5d9ff53b6369a9277f17021c3733f18f7d757
+    version: 1.1.1
+    sha256: 5725bd04acdd9bedefddf899fd1bae19f914dd2d8db3d60eae4156d0324202c6
     fail-on: proven
 ```
 
-Pin the action reference to a reviewed commit and copy the SHA-256 matching the
-Linux runner architecture from the signed release `SHA256SUMS`. On pull
+For security-critical automation, pin the action reference to a reviewed full
+commit SHA and copy the SHA-256 matching the Linux runner architecture from the
+release `SHA256SUMS`. The `v1` tag is a compatible-update channel and can move;
+it is not equivalent to a fixed commit SHA. On pull
 requests from forks, the action has no automatic access to repository secrets;
 the command and workspace inputs must still be safe for untrusted source code.
 The `fail-on` policy is applied only after evidence upload, so a proven result


### PR DESCRIPTION
## Summary

- enables GitHub Immutable Releases for `ClusterPilot-System/worldbisect` (verified through the repository API)
- publishes future full SemVer releases draft-first so GitHub locks the complete asset set and release tag only at publication
- excludes the moving `v1` compatibility tag from the release workflow
- documents `v1` as a compatible-update channel and full commit-SHA plus archive/attestation verification for security-critical Action use
- preserves `v1.0.0`, `v1.1.0`, and `v1.1.1` without moving or rebuilding historical releases

## Security and compatibility

- no CLI, API, artifact, or Action input/output contract changes
- historical releases remain unchanged; GitHub Immutable Releases apply only to future published releases
- `v1` will be created at the reviewed `v1.1.1` commit after this workflow change reaches `main`, avoiding an erroneous release workflow invocation from the old trigger

## Validation

- `git diff --check`
- release workflow YAML parsing
- Bash syntax check for `scripts/release-check.sh`
- verified `v1.1.0` and `v1.1.1` GPG tag signatures
- verified the documented `v1.1.1` commit SHA and Linux AMD64 release digest against GitHub release metadata

Refs #33